### PR TITLE
Protection against undefiend temp directory

### DIFF
--- a/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
+++ b/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
@@ -74,6 +74,11 @@
 #include <sys/times.h>
 #endif // WIN32
 
+#ifndef ILM_IMF_TEST_IMAGEDIR
+    #define ILM_IMF_TEST_IMAGEDIR
+#endif
+
+
 using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;

--- a/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
@@ -60,6 +60,11 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#ifndef ILM_IMF_TEST_IMAGEDIR
+    #define ILM_IMF_TEST_IMAGEDIR
+#endif
+
+
 using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;


### PR DESCRIPTION
A couple of these test files wouldn't build without the temp directory defined because they were missing this.
