### PR TITLE
Use constants from ImfPartType.h

### DIFF
--- a/OpenEXR/IlmImfTest/testMultiPartApi.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartApi.cpp
@@ -42,6 +42,7 @@
 #include "tmpDir.h"
 #include "testMultiPartApi.h"
 
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfOutputFile.h>
@@ -154,10 +155,10 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Task>&
         switch (partType)
         {
             case 0:
-                header.setType("scanlineimage");
+                header.setType(SCANLINEIMAGE);
                 break;
             case 1:
-                header.setType("tiledimage");
+                header.setType(TILEDIMAGE);
                 break;
         }
 

--- a/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
@@ -42,6 +42,7 @@
 #include "tmpDir.h"
 #include "testMultiPartThreading.h"
 
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfOutputFile.h>
@@ -395,10 +396,10 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Writin
         switch (partType)
         {
             case 0:
-                header.setType("scanlineimage");
+                header.setType(SCANLINEIMAGE);
                 break;
             case 1:
-                header.setType("tiledimage");
+                header.setType(TILEDIMAGE);
                 break;
         }
 

--- a/OpenEXR/IlmImfTest/testMultiScanlinePartThreading.cpp
+++ b/OpenEXR/IlmImfTest/testMultiScanlinePartThreading.cpp
@@ -43,6 +43,7 @@
 
 #include "testMultiScanlinePartThreading.h"
 
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfOutputFile.h>
@@ -245,7 +246,7 @@ void generateFiles(int pixelTypes[])
                 break;
         }
 
-        header.setType("scanlineimage");
+        header.setType(SCANLINEIMAGE);
 
         headers.push_back(header);
     }

--- a/OpenEXR/IlmImfTest/testMultiTiledPartThreading.cpp
+++ b/OpenEXR/IlmImfTest/testMultiTiledPartThreading.cpp
@@ -43,6 +43,7 @@
 
 #include "testMultiTiledPartThreading.h"
 
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfOutputFile.h>
@@ -258,7 +259,7 @@ void generateFiles()
                 break;
         }
 
-        header.setType("tiledimage");
+        header.setType(TILEDIMAGE);
 
         int tileX = tileSize;
         int tileY = tileSize;

--- a/OpenEXR/exrbuild/exrbuild.cpp
+++ b/OpenEXR/exrbuild/exrbuild.cpp
@@ -34,6 +34,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 
+#include <ImfPartType.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfStringAttribute.h>
@@ -493,13 +494,13 @@ int main(int argc,char * argv[])
 	  //for every type of data 
     Header header = headers[p];
     std::string type = header.type();
-    if(type=="scanlineimage")
+    if(type==SCANLINEIMAGE)
     {
       copy_scanlineimage(*inputs[p],out,partnums[p],p,views[p]);
-    }else if(type=="tiledimage")
+    }else if(type==TILEDIMAGE)
     {
       copy_tiledimage(*inputs[p],out,partnums[p],p,views[p]);
-    }else if(type=="deepscanline")
+    }else if(type==DEEPSCANLINE)
     {
       copy_scanlinedeep(*inputs[p],out,partnums[p],p);
     }

--- a/OpenEXR/exrmaketiled/main.cpp
+++ b/OpenEXR/exrmaketiled/main.cpp
@@ -398,7 +398,7 @@ main(int argc, char **argv)
         }
 
         Header h = input.header (partnum);
-        if (h.type() == "deeptile" || h.type() == "deepscanline")
+        if (h.type() == DEEPTILE || h.type() == DEEPSCANLINE)
         {
             cerr << "Cannot make tile for deep data" << endl;
             exit(1);

--- a/OpenEXR/exrmaketiled/makeTiled.cpp
+++ b/OpenEXR/exrmaketiled/makeTiled.cpp
@@ -585,7 +585,7 @@ makeTiled (const char inFileName[],
             //
             // set tileDescription, type, and chunckcount for multipart
             //
-            header.setType("tiledimage");
+            header.setType(TILEDIMAGE);
             int chunkcount = getChunkOffsetTableSize(header, true);
             header.setChunkCount(chunkcount);
 
@@ -717,25 +717,25 @@ makeTiled (const char inFileName[],
         {
             Header header = headers[p];
             std::string type = header.type();
-            if (type == "tiledimage")
+            if (type == TILEDIMAGE)
             {
                 TiledInputPart in (input, p);
                 TiledOutputPart out (output, p);
                 out.copyPixels (in);
             }
-            else if (type == "scanlineimage")
+            else if (type == SCANLINEIMAGE)
             {
                 using std::max;  InputPart in (input, p);
                 OutputPart out (output, p);
                 out.copyPixels (in);
             }
-            else if (type == "deepscanline")
+            else if (type == DEEPSCANLINE)
             {
                 DeepScanLineInputPart in (input,p);
                 DeepScanLineOutputPart out (output,p);
                 out.copyPixels (in);
             }
-            else if (type == "deeptile")
+            else if (type == DEEPTILE)
             {
                 DeepTiledInputPart in (input,p);
                 DeepTiledOutputPart out (output,p);

--- a/OpenEXR/exrmaketiled/makeTiled.h
+++ b/OpenEXR/exrmaketiled/makeTiled.h
@@ -42,6 +42,7 @@
 //
 //----------------------------------------------------------------------------
 
+#include <ImfPartType.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfTileDescription.h>

--- a/OpenEXR/exrstdattr/main.cpp
+++ b/OpenEXR/exrstdattr/main.cpp
@@ -40,6 +40,7 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfStandardAttributes.h>
@@ -824,25 +825,25 @@ main(int argc, char **argv)
         {
             Header header = input.header (p);
             std::string type = header.type();
-            if (type == "tiledimage")
+            if (type == TILEDIMAGE)
             {
                 TiledInputPart in (input, p);
                 TiledOutputPart out (output, p);
                 out.copyPixels (in);
             }
-            else if (type == "scanlineimage")
+            else if (type == SCANLINEIMAGE)
             {
                 InputPart in (input, p);
                 OutputPart out (output, p);
                 out.copyPixels (in);
             }
-            else if (type == "deepscanline")
+            else if (type == DEEPSCANLINE)
             {
                 DeepScanLineInputPart in (input,p);
                 DeepScanLineOutputPart out (output,p);
                 out.copyPixels (in);
             }
-            else if (type == "deeptile")
+            else if (type == DEEPTILE)
             {
                 DeepTiledInputPart in (input,p);
                 DeepTiledOutputPart out (output,p);

--- a/OpenEXR_Viewers/exrdisplay/loadImage.cpp
+++ b/OpenEXR_Viewers/exrdisplay/loadImage.cpp
@@ -52,7 +52,7 @@
 #include <ImfChannelList.h>
 #include <Iex.h>
 
-
+#include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfInputPart.h>
 #include <ImfTiledInputPart.h>
@@ -909,7 +909,7 @@ loadImage (const char fileName[],
     Header h = inmaster.header(partnum);
     std::string  type = h.type();
 
-    if (type == "deeptile")
+    if (type == DEEPTILE)
     {
         loadDeepTileImage(inmaster,
                           partnum,
@@ -919,7 +919,7 @@ loadImage (const char fileName[],
                           zbuffer,
                           sampleCount);
     }
-    else if(type == "deepscanline")
+    else if(type == DEEPSCANLINE)
     {
         loadDeepScanlineImage(inmaster,
                               partnum,


### PR DESCRIPTION
Replaced instances where the name of the file type was being used instead of the defined constants.
