### PR TITLE
Added missing break statement

### DIFF
--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -526,6 +526,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 case B44_COMPRESSION :
                 case B44A_COMPRESSION :
                     rowsizes[i]=32;
+                    break;
                 case ZIP_COMPRESSION :
                 case PXR24_COMPRESSION :
                     rowsizes[i]=16;


### PR DESCRIPTION
This was causing a file written with OpenEXR 1.7 to not get read properly because the chunkOffsets were not reconstructed properly.

Curiously, older sample EXR files (like desk.exr) didn't have the problem.
