### PR TITLE
add missing header for mset by mingw

### DIFF
--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -45,11 +45,11 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <string.h>
 #include <ImfHuf.h>
 #include <ImfInt64.h>
 #include <ImfAutoArray.h>
 #include "Iex.h"
-#include <string.h>
 #include <assert.h>
 #include <algorithm>
 


### PR DESCRIPTION
fix undefined mset and other symbols introduced. string.h provides these for mingw.
