### PR TITLE
ImfHybridInputFile

### DIFF
--- a/OpenEXR/IlmImf/ImfHybridInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfHybridInputFile.cpp
@@ -1,0 +1,120 @@
+/*
+ *  ImfHybridInputFile.cpp
+ *  OpenEXR
+ *
+ *  Created by Brendan Bolles on 3/19/13.
+ *  Copyright 2013 fnord. All rights reserved.
+ *
+ */
+
+#include "ImfHybridInputFile.h"
+
+#include "ImfInputPart.h"
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
+
+
+using namespace std;
+using IMATH_NAMESPACE::Box2i;
+
+
+HybridInputFile::HybridInputFile(const char fileName[], int numThreads, bool reconstructChunkOffsetTable) :
+	_multiPart(fileName, numThreads, reconstructChunkOffsetTable)
+{
+	setup();
+}
+
+
+HybridInputFile::HybridInputFile(IStream& is, int numThreads, bool reconstructChunkOffsetTable) :
+	_multiPart(is, numThreads, reconstructChunkOffsetTable)
+{
+	setup();
+}
+
+
+bool
+HybridInputFile::isComplete() const
+{
+	for(int i=0; i < _multiPart.parts(); i++)
+	{
+		if( !_multiPart.partComplete(i) )
+			return false;
+	}
+	
+	return true;
+}
+
+
+void
+HybridInputFile::readPixels(int scanLine1, int scanLine2)
+{
+	for(int n=0; n < _multiPart.parts(); n++)
+	{
+		const Box2i &dataW = _multiPart.header(n).dataWindow();
+		
+		FrameBuffer part_fb;
+	
+		for(FrameBuffer::ConstIterator i = _frameBuffer.begin(); i != _frameBuffer.end(); i++)
+		{
+			if( _map.find( i.name() ) != _map.end() )
+			{
+				const HybridChannel &hyChan = _map[ i.name() ];
+				
+				if(hyChan.part == n)
+				{
+					part_fb.insert( hyChan.name, i.slice() );
+				}
+			}
+			else if(n == 0)
+			{
+				// for channels that will be simply be filled
+				string name_never_loaded = string("zzNOLOADzz") + i.name();
+				
+				part_fb.insert( name_never_loaded, i.slice() );
+			}
+		}
+		
+		if(part_fb.begin() != part_fb.end()) // i.e. it's not empty
+		{
+			InputPart inPart(_multiPart, n);
+			
+			inPart.setFrameBuffer(part_fb);
+			
+			inPart.readPixels(scanLine1, scanLine2);
+		}
+	}
+}
+
+
+void
+HybridInputFile::setup()
+{
+	for(int n=0; n < _multiPart.parts(); n++)
+	{
+		const Header &head = _multiPart.header(n);
+		
+		// this will make a dataWindow that can hold the dataWindows of every part
+		_dataWindow.extendBy( head.dataWindow() );
+		
+		// all displayWindows should be the same, actually
+		_displayWindow.extendBy( head.displayWindow() );
+		
+		
+		const ChannelList &chans = head.channels();
+
+		for(ChannelList::ConstIterator i = chans.begin(); i != chans.end(); ++i)
+		{
+			const bool rename = (_multiPart.parts() > 1);
+			
+			const string hybrid_name = (rename ? head.name() + "." + i.name() : i.name());
+			
+			_map[ hybrid_name ] = HybridChannel(n, i.name());
+			
+			_chanList.insert(hybrid_name, i.channel());
+		}
+	}
+}
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/OpenEXR/IlmImf/ImfHybridInputFile.h
+++ b/OpenEXR/IlmImf/ImfHybridInputFile.h
@@ -1,0 +1,86 @@
+/*
+ *  ImfHybridInputFile.h
+ *  OpenEXR
+ *
+ *  Created by Brendan Bolles on 3/19/13.
+ *  Copyright 2013 fnord. All rights reserved.
+ *
+ */
+
+#ifndef INCLUDED_IMF_HYBRID_INPUT_FILE_H
+#define INCLUDED_IMF_HYBRID_INPUT_FILE_H
+
+#include "ImfHeader.h"
+#include "ImfMultiPartInputFile.h"
+#include "ImfFrameBuffer.h"
+#include "ImfChannelList.h"
+#include "ImathBox.h"
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
+
+class IMF_EXPORT HybridInputFile : public GenericInputFile
+{
+  public:
+	HybridInputFile(const char fileName[],
+					int numThreads = globalThreadCount(),
+					bool reconstructChunkOffsetTable = true);
+					
+	HybridInputFile(IStream& is,
+					int numThreads = globalThreadCount(),
+					bool reconstructChunkOffsetTable = true);
+
+	virtual ~HybridInputFile() {}
+	
+	
+	int parts() const { return _multiPart.parts(); }
+
+	const Header &  header(int n) const { return _multiPart.header(n); }
+	
+	int			    version () const { return _multiPart.version(); }
+	
+	bool		isComplete () const;
+	
+	const ChannelList &		channels () const { return _chanList; }
+	
+	const IMATH_NAMESPACE::Box2i & dataWindow() const { return _dataWindow; }
+	const IMATH_NAMESPACE::Box2i & displayWindow() const { return _displayWindow; }
+	
+	
+	void		setFrameBuffer (const FrameBuffer &frameBuffer) { _frameBuffer = frameBuffer; }
+	
+	const FrameBuffer &	frameBuffer () const { return _frameBuffer; }
+	
+    void		readPixels (int scanLine1, int scanLine2);
+    void		readPixels (int scanLine) { readPixels(scanLine, scanLine); }
+	
+  private:
+	void setup();
+
+  private:
+	MultiPartInputFile _multiPart;
+	
+	IMATH_NAMESPACE::Box2i _dataWindow;
+	IMATH_NAMESPACE::Box2i _displayWindow;
+	
+	FrameBuffer		_frameBuffer;
+	
+	typedef struct HybridChannel {
+		int part;
+		std::string name;
+		
+		HybridChannel(int p=0, const std::string &n="") : part(p), name(n) {}
+	}HybridChannel;
+	
+	typedef std::map<std::string, HybridChannel> HybridChannelMap;
+	
+	HybridChannelMap _map;
+	
+	ChannelList _chanList;
+};
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#endif // INCLUDED_IMF_HYBRID_INPUT_FILE_H


### PR DESCRIPTION
I wanted to show you guys something I threw together today in case you thought it might be a good addition to the EXR library (after it's been cleaned up to look presentable). 

We now have multi-part EXR files. Apps not prepared to deal with the extra complexity can continue to use ImfInputFile, but then they only have access to the channels in the first part. In some cases, multiple parts doesn't really fit into the app's paradigm.

This ImfHybridInputFile class takes a multi-part file and flattens it into a single list of channels (and single dataWindow) like we had before, making it possible to access all the channels in a multi-part file without much reworking of code. It appends the part name to the channel names to make them unique.

Would other people find this functionality useful?

![Screen shot 2013-03-20 at 3 06 11 AM](https://f.cloud.github.com/assets/1205955/280056/e0662f7e-9145-11e2-93a5-1c55eb99aeef.png)
