### PR TITLE
C++11 threads

### DIFF
--- a/IlmBase/IlmThread/IlmThread.cpp
+++ b/IlmBase/IlmThread/IlmThread.cpp
@@ -41,7 +41,7 @@
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) &&!(_WIN64) && !(HAVE_PTHREAD)
+#if !defined (_WIN32) &&!(_WIN64) && !(HAVE_PTHREAD) && !(HAVE_STDTHREAD)
 
 #include "IlmThread.h"
 #include "Iex.h"

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -103,6 +103,8 @@
     #include <process.h>
 #elif HAVE_PTHREAD
     #include <pthread.h>
+#elif HAVE_STDTHREAD
+    #include <thread>
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -131,6 +133,8 @@ class ILMTHREAD_EXPORT Thread
 	HANDLE _thread;
     #elif HAVE_PTHREAD
 	pthread_t _thread;
+    #elif HAVE_STDTHREAD
+	std::thread _thread;
     #endif
 
     void operator = (const Thread& t);	// not implemented

--- a/IlmBase/IlmThread/IlmThreadMutex.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutex.cpp
@@ -41,7 +41,7 @@
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD)
+#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD) && !(HAVE_STDTHREAD)
 
 #include "IlmThreadMutex.h"
 

--- a/IlmBase/IlmThread/IlmThreadMutex.h
+++ b/IlmBase/IlmThread/IlmThreadMutex.h
@@ -78,6 +78,8 @@
     #include <windows.h>
 #elif HAVE_PTHREAD
     #include <pthread.h>
+#elif HAVE_STDTHREAD
+    #include <mutex>
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -101,6 +103,8 @@ class ILMTHREAD_EXPORT Mutex
 	mutable CRITICAL_SECTION _mutex;
     #elif HAVE_PTHREAD
 	mutable pthread_mutex_t _mutex;
+    #elif HAVE_STDTHREAD
+	mutable std::mutex _mutex;
     #endif
 
     void operator = (const Mutex& M);	// not implemented

--- a/IlmBase/IlmThread/IlmThreadMutexStd.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexStd.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -34,25 +34,46 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class Semaphore -- dummy implementation for
-//	for platforms that do not support threading
+//  class Mutex -- implementation for
+//  platforms that support libc++ (C++11) threads
 //
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD) && !(HAVE_STDTHREAD)
-#include "IlmThreadSemaphore.h"
+#if HAVE_STDTHREAD
+
+#include "IlmThreadMutex.h"
+#include "Iex.h"
+#include <assert.h>
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 
-Semaphore::Semaphore (unsigned int value) {}
-Semaphore::~Semaphore () {}
-void Semaphore::wait () {}
-bool Semaphore::tryWait () {return true;}
-void Semaphore::post () {}
-int Semaphore::value () const {return 0;}
+Mutex::Mutex ()
+{
+    // empty
+}
+
+
+Mutex::~Mutex ()
+{
+    // empty
+}
+
+
+void
+Mutex::lock () const
+{
+    _mutex.lock ();
+}
+
+
+void
+Mutex::unlock () const
+{
+    _mutex.unlock ();
+}
 
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/IlmBase/IlmThread/IlmThreadSemaphore.h
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.h
@@ -54,6 +54,8 @@
     #include <windows.h>
 #elif HAVE_PTHREAD && !HAVE_POSIX_SEMAPHORES
     #include <pthread.h>
+#elif HAVE_STDTHREAD && !HAVE_POSIX_SEMAPHORES
+	#include <mutex>
 #elif HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
     #include <semaphore.h>
 #endif
@@ -96,6 +98,23 @@ class ILMTHREAD_EXPORT Semaphore
 
 	mutable sema_t _semaphore;
 
+	#elif HAVE_STDTHREAD && !HAVE_POSIX_SEMAPHORES
+	
+	//
+	// If the platform has libc++ (C++11) threads but no semapohores,
+	// then we implement them ourselves using condition variables
+	//
+	
+	struct sema_t
+	{
+	    unsigned int count;
+	    unsigned long numWaiting;
+	    std::mutex mutex;
+	    std::condition_variable nonZero;
+	};
+	
+	mutable sema_t _semaphore;
+	
     #elif HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
 
 	mutable sem_t _semaphore;

--- a/IlmBase/IlmThread/IlmThreadStd.cpp
+++ b/IlmBase/IlmThread/IlmThreadStd.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -34,25 +34,56 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class Semaphore -- dummy implementation for
-//	for platforms that do not support threading
+//  class Thread -- implementation for
+//  platforms that support libc++ (C++11) threads
 //
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD) && !(HAVE_STDTHREAD)
-#include "IlmThreadSemaphore.h"
+#if HAVE_STDTHREAD
+
+#include "IlmThread.h"
+#include "Iex.h"
+
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 
-Semaphore::Semaphore (unsigned int value) {}
-Semaphore::~Semaphore () {}
-void Semaphore::wait () {}
-bool Semaphore::tryWait () {return true;}
-void Semaphore::post () {}
-int Semaphore::value () const {return 0;}
+bool
+supportsThreads ()
+{
+    return true;
+}
+
+namespace {
+    
+    void
+    threadLoop (void * t)
+    {
+        return (reinterpret_cast<Thread*>(t))->run();
+    }
+    
+} // namespace
+
+
+Thread::Thread ()
+{
+    // empty
+}
+
+
+Thread::~Thread ()
+{
+    _thread.join ();
+}
+
+
+void
+Thread::start ()
+{
+    _thread = std::thread (threadLoop, this);
+}
 
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/IlmBase/config/IlmBaseConfig.h.in
+++ b/IlmBase/config/IlmBaseConfig.h.in
@@ -1,4 +1,11 @@
 //
+// Define and set to 1 if the target system has libc++ (C++11) thread support
+// and you want IlmBase to use it for multithreaded file I/O.
+//
+
+#undef HAVE_STDTHREAD
+
+//
 // Define and set to 1 if the target system has POSIX thread support
 // and you want IlmBase to use it for multithreaded file I/O.
 //


### PR DESCRIPTION
In my copious spare time I went ahead and added optional for support for the new standard thread library in C++11. The C++11 thread classes are actually pretty similar to IlmThread.

This has been tested in the only C++11 compiler I've got, Xcode 4. Some changes will have to be made to CMake files to get these to build the standard way.
