### PR TITLE
Fix for a crash when uncompressing deep tiled data

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -600,6 +600,10 @@ TileBufferTask::execute ()
                 int count = _ifd->getSampleCount(x - xOffset, y - yOffset);
                 for (unsigned int c = 0; c < _ifd->slices.size(); ++c)
                 {
+		    // This slice does not exist in the file.
+		    if (_ifd->slices[c]->fill)
+			continue;
+		    
                     sizeOfTile += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
                     bytesPerLine += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
                 }


### PR DESCRIPTION
Make sure to skip over slices that will only be filled when computing the uncompressed pixel size. Otherwise chunks that compressed to larger sizes than the original will fail to load.
