### PR TITLE
Windows crash from out-of-range vector access

### DIFF
--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
@@ -533,7 +533,7 @@ CompositeDeepScanLine::readPixels(int start, int end)
           {
               for(size_t part=0;part<parts;part++)
               {
-                      pointers[part][channel][pixel]=(offset < overall_sample_count ? &samples[channel][offset] : NULL);
+                      pointers[part][channel][pixel]=(offset < samples[channel].size() ? &samples[channel][offset] : NULL);
                       offset+=counts[part][pixel];
               }
           }


### PR DESCRIPTION
I was getting a crash in Windows from this line. Near the end of this loop offset == overall_sample_count, and that's the problem.

Windows doesn't like it if you try to access the address of an element outside
the range of the vector size. So if the size is n, &vec[n] will crash
(the last element is vec[n-1]). This also applies to &vec[0]
on an empty vector.

GCC is OK with it and I think returns NULL, but in Windows it will crash (at
least with Visual Studio 2008). Is there a C++ spec that says the vector should return NULL in this case? Otherwise doesn't seem like a kosher thing to do.
