### PR TITLE
Add missing halfExport.h header to IlmBase cmake configuration

### DIFF
--- a/IlmBase/Half/CMakeLists.txt
+++ b/IlmBase/Half/CMakeLists.txt
@@ -49,6 +49,7 @@ INSTALL ( FILES
   half.h
   halfFunction.h
   halfLimits.h
+  halfExport.h
   DESTINATION
   include/OpenEXR
 )


### PR DESCRIPTION
Building on Windows using MS VC 2010 and cmake as per the
README.cmake.txt help file.

IlmBase configures (cmake) OK, then builds and installs.

OpenEXR configures OK but build fails with errors :

C:\users\dv\dev\openexr.git\IlmBase\output\include\OpenEXR\half.h(88):
fatal error C1083: Cannot open include file: 'halfExport.h': No such file or directory

Header "halfExport.h" is missing in IlmBase build output header dir :

<output>\OpenEXR\include

To fix, make sure this header is included by cmake, adding to :

IlmBase/Half/CMakeLists.txt
