### PR TITLE
Ostream constructor version field fix

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -869,7 +869,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile
         _data->_streamData->currentPosition = _data->_streamData->os->tellp();
 
         // Write header and empty offset table to the file.
-        writeMagicNumberAndVersionField(*_data->_streamData->os, header);
+        writeMagicNumberAndVersionField(*_data->_streamData->os, _data->header);
         _data->previewPosition =
                 _data->header.writeTo (*_data->_streamData->os);
         _data->lineOffsetsPosition =

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -1110,7 +1110,7 @@ DeepTiledOutputFile::DeepTiledOutputFile
         _data->_streamData->currentPosition = _data->_streamData->os->tellp();
 
         // Write header and empty offset table to the file.
-        writeMagicNumberAndVersionField(*_data->_streamData->os, header);
+        writeMagicNumberAndVersionField(*_data->_streamData->os, _data->header);
         _data->previewPosition = _data->header.writeTo (*_data->_streamData->os, true);
         _data->tileOffsetsPosition = _data->tileOffsets.writeTo (*_data->_streamData->os);
 	_data->multipart = false;

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -909,7 +909,7 @@ TiledOutputFile::TiledOutputFile
 	_streamData->currentPosition = _streamData->os->tellp();
 
 	// Write header and empty offset table to the file.
-	writeMagicNumberAndVersionField(*_streamData->os, header);
+	writeMagicNumberAndVersionField(*_streamData->os, _data->header);
 	_data->previewPosition = _data->header.writeTo (*_streamData->os, true);
         _data->tileOffsetsPosition = _data->tileOffsets.writeTo (*_streamData->os);
 	


### PR DESCRIPTION
Found this bug with the OStream constructors for tiled, deep scanline, and deep tiled. The regular (scanline) OutputFile OStream constructor already has this set up properly. 
