### PR TITLE
Fix for CMake under linux.

### DIFF
--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -136,7 +136,7 @@ ADD_DEPENDENCIES ( IlmImf b44ExpLogTable )
 SET_SOURCE_FILES_PROPERTIES (
   ImfB44Compressor.cpp
   PROPERTIES
-  OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/b44ExpLogTable.h
+  OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/IlmImf/b44ExpLogTable.h
 )
 
 # Libraries
@@ -151,6 +151,8 @@ INSTALL ( TARGETS
 INSTALL ( FILES
   ${CMAKE_SOURCE_DIR}/config/OpenEXRConfig.h
   ImfForward.h
+  ImfNamespace.h
+  ImfPartHelper.h
   ImfExport.h
   ImfAttribute.h
   ImfBoxAttribute.h

--- a/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
@@ -6,7 +6,9 @@ ADD_EXECUTABLE ( IlmImfFuzzTest
   testFuzzDeepTiles.cpp
   testFuzzDeepScanLines.cpp
   testFuzzScanLines.cpp
+  testFuzzDeepScanLines.cpp
   testFuzzTiles.cpp
+  testFuzzDeepTiles.cpp
   )
 
 TARGET_LINK_LIBRARIES ( IlmImfFuzzTest 


### PR DESCRIPTION
In Blender project, we have an helper bash script users can use to automatically install and/or compile needed dependencies, and we use CMake tool to build needed libs.

This patch fixes OpenEXR cmake for linux.

Thanks for checking it,
Bastien (aka mont29).
