### PR TITLE
Small windows fixes

### DIFF
--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -24,6 +24,10 @@ IF ( NOT WIN32)
   ADD_DEFINITIONS ( -pthread )
 ENDIF ()
 
+IF ( WIN32)
+  ADD_DEFINITIONS ( -DPLATFORM_WINDOWS )
+ENDIF ()
+
 INCLUDE_DIRECTORIES ( Iex IexMath Imath Half config IlmThread IexTest ImathTest HalfTest )
 
 MACRO(GET_TARGET_PROPERTY_WITH_DEFAULT _variable _target _property _default_value)

--- a/OpenEXR/exrmultipart/exrmultipart.cpp
+++ b/OpenEXR/exrmultipart/exrmultipart.cpp
@@ -63,6 +63,7 @@
 #include <utility> // pair
 #include <stdlib.h>
 #include <sstream>
+#include <cctype>
 #include <assert.h>
 #include <cctype>
 


### PR DESCRIPTION
Two very small fixes to compile on windows, using the compilers on Windows SDK 7.1.
