### PR TITLE
Update exrmultipart.cpp for windows build

### DIFF
--- a/OpenEXR/exrmultipart/exrmultipart.cpp
+++ b/OpenEXR/exrmultipart/exrmultipart.cpp
@@ -64,6 +64,7 @@
 #include <stdlib.h>
 #include <sstream>
 #include <assert.h>
+#include <cctype>
 
 using std::cerr;
 using std::cout;


### PR DESCRIPTION
Usage of isdigit without including cctype results in build fail in windows(VC++ 2012)
