### PR TITLE
Build system check for inline asm with AVX instructions. 

### DIFF
--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -66,6 +66,26 @@ IF (USE_ZLIB_WINAPI)
   ADD_DEFINITIONS(-DZLIB_WINAPI)
 ENDIF ()
 
+# Test for GCC-style inline asm support with AVX instructions
+INCLUDE (CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES (
+	"
+	int main()
+	{
+	 #if defined(__GNUC__) && defined(__SSE2__) 
+		 int n   = 0;
+		 int eax = 0;
+		 int edx = 0;
+		 __asm__(
+			 \"xgetbv     ;\"
+			 \"vzeroupper  \"
+			 : \"=a\"(eax), \"=d\"(edx) : \"c\"(n) : );
+	 #else
+		 #error No GCC style inline asm supported for AVX instructions
+	 #endif
+	}
+	" HAVE_GCC_INLINE_ASM_AVX)
+
 ##########################
 # OpenEXRConfig.h generation
 ##########################
@@ -103,8 +123,12 @@ FILE ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/config/OpenEXRConfig.h "
 // Version as a single hex number, e.g. 0x01000300 == 1.0.3
 #define OPENEXR_VERSION_HEX ((OPENEXR_VERSION_MAJOR << 24) | \\
                              (OPENEXR_VERSION_MINOR << 16) | \\
-                             (OPENEXR_VERSION_PATCH <<  8))
+                             (OPENEXR_VERSION_PATCH <<  8))\n
 ")
+
+IF (HAVE_GCC_INLINE_ASM_AVX)
+  FILE ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/config/OpenEXRConfig.h "#define OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX 1\n" )
+ENDIF()
   
   
 ##########################

--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -46,6 +46,8 @@
 #include "ImfNamespace.h"
 #include "ImfSimd.h"
 #include "ImfSystemSpecific.h"
+#include "OpenEXRConfig.h"
+
 #include <half.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -55,11 +57,10 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 #define _AVX_ALIGNMENT_MASK 0x1F
 
 //
-// Test if we should enable GCC inline asm paths
+// Test if we should enable GCC inline asm paths for AVX
 //
-//  
 
-#if defined(IMF_HAVE_SSE2) && defined(__GNUC__) 
+#ifdef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX 
 
     #define IMF_HAVE_GCC_INLINEASM
 
@@ -67,7 +68,7 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
         #define IMF_HAVE_GCC_INLINEASM_64
     #endif /* __LP64__ */
 
-#endif /* IMF_HAVE_SSE2 && __GNUC__ */
+#endif /* OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX */
 
 //
 // A simple 64-element array, aligned properly for SIMD access. 

--- a/OpenEXR/config/OpenEXRConfig.h.in
+++ b/OpenEXR/config/OpenEXRConfig.h.in
@@ -30,6 +30,12 @@
 #undef OPENEXR_IMF_HAVE_LARGE_STACK
 
 //
+// Define if we can support GCC style inline asm with AVX instructions
+//
+
+#undef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX
+
+//
 // Current internal library namepace name
 //
 #undef OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -174,6 +174,38 @@ AC_TRY_COMPILE([#include <stdio.h>],
 CFLAGS=$old_cflags
 AC_MSG_RESULT([$EXTRA_OPT_CFLAGS])
 
+dnl Check to see if the toolset supports AVX instructions in inline asm
+AC_MSG_CHECKING(for AVX instructions in GCC style inline asm)
+gcc_inline_asm_avx="no"
+AC_COMPILE_IFELSE(
+    [
+        AC_LANG_PROGRAM([],
+        [
+             #if defined(__GNUC__) && defined(__SSE2__) 
+                 int n   = 0;
+                 int eax = 0;
+                 int edx = 0;
+                 __asm__(
+                     "xgetbv     \n"
+                     "vzeroupper  "
+                     : "=a"(eax), "=d"(edx) : "c"(n) : );
+             #else
+                 #error No GCC style inline asm supported for AVX instructions
+             #endif
+        ]) 
+   ],
+   [
+      gcc_inline_asm_avx="yes"
+   ],
+   [
+      gcc_inline_asm_avx="no"
+   ]
+)
+AC_MSG_RESULT([$gcc_inline_asm_avx])
+if test "x${gcc_inline_asm_avx}" == xyes ; then
+    AC_DEFINE(OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX)
+fi
+
 dnl Platform-specific stuff
 case "$host" in
 *linux*)


### PR DESCRIPTION
This should hopefully catch cases where the toolchain doesn't support inline asm + AVX. Added cmake + autoconf checks of a very simple inline asm line that uses the sorts of instructions we're apt to use. If successful, define `OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX` in `OpenEXRConfig.h`.
