### PR TITLE
exrstdattr: Headers are not initialized from the input file

### DIFF
--- a/OpenEXR/exrstdattr/main.cpp
+++ b/OpenEXR/exrstdattr/main.cpp
@@ -828,11 +828,11 @@ main(int argc, char **argv)
 
 	MultiPartInputFile in (inFileName);
 	int numParts = in.parts();
-        vector <Header> headers (numParts);
+        vector <Header> headers;
 
         for (int part = 0; part < numParts; ++part)
         {
-            Header &h = headers[part];
+            Header h = in.header (part);
 
             for (int i = 0; i < attrs.size(); ++i)
             {
@@ -851,6 +851,8 @@ main(int argc, char **argv)
                     return 1;
                 }
             }
+
+            headers.push_back(h);
         }
 
         //


### PR DESCRIPTION
It looks like that as part of https://github.com/openexr/openexr/commit/ecc9fc53c954e2430539004f8ca1c8ce35ce43b1, the vector of headers to which new attributes are added switched to:

```
   MultiPartInputFile in (inFileName);
   int numParts = in.parts();
   vector <Header> headers (numParts);
```

And doesn't seem to ever be initialized with the header from the input file parts. This seems to cause issues with calls to `Header::type()`. In it's current state, `exrstdattr` doesn't seem to even work, at least for me.
