### PR TITLE
Memory leak in ImfDwaCompressorSimd.h

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -108,12 +108,13 @@ class SimdAlignedBuffer64
             _handle = (char *) EXRAllocAligned
                 (64 * sizeof(T), _SSE_ALIGNMENT);
 
-            if ((size_t)_handle & (_SSE_ALIGNMENT - 1))
+            if (((size_t)_handle & (_SSE_ALIGNMENT - 1)) == 0)
             {
                 _buffer = (T *)_handle;
                 return;
             }
 
+            EXRFreeAligned(_handle);
             _handle = (char *) EXRAllocAligned
                 (64 * sizeof(T) + _SSE_ALIGNMENT, _SSE_ALIGNMENT);
 


### PR DESCRIPTION
The logic in `SimdAlignedBuffer64::alloc()` is backwards and leaks memory if the first call to `EXRAllocAligned()` fails to return an aligned buffer.
