### PR TITLE
Make PyIlmBase pkg-config actually link its own libraries

### DIFF
--- a/PyIlmBase/PyIlmBase.pc.in
+++ b/PyIlmBase/PyIlmBase.pc.in
@@ -7,5 +7,6 @@ PyIlmBase_includedir=@includedir@/OpenEXR
 Name: PyIlmBase
 Description: Python bindings for the IlmBase libraries
 Version: @PYILMBASE_VERSION@
-Libs: -L${libdir} @ILMBASE_LDFLAGS@ -lIlmImf -lz @ILMBASE_LIBS@
-Cflags: @ILMBASE_CXXFLAGS@ -I${PyIlmBase_includedir}
+Libs: -L${libdir} -lPyImath -lPyIex
+Requires: IlmBase
+Cflags: -I${PyIlmBase_includedir}


### PR DESCRIPTION
PyImath and PyIex were missing
