### PR TITLE
Adding rawPixelDataToBuffer() function for access to compressed scanlines

### DIFF
--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -854,6 +854,39 @@ InputFile::rawPixelData (int firstScanLine,
 }
 
 
+
+
+void
+InputFile::rawPixelDataToBuffer (int scanLine,
+                                 char *pixelData,
+                                 int &pixelDataSize) const
+{
+    try
+    {
+        if (_data->dsFile)
+        {
+            throw IEX_NAMESPACE::ArgExc ("Tried to read a raw scanline "
+                                         "from a deep image.");
+        }
+        
+        else if (_data->isTiled)
+        {
+            throw IEX_NAMESPACE::ArgExc ("Tried to read a raw scanline "
+                                         "from a tiled image.");
+        }
+        
+        _data->sFile->rawPixelDataToBuffer(scanLine, pixelData, pixelDataSize);
+    }
+    catch (IEX_NAMESPACE::BaseExc &e)
+    {
+        REPLACE_EXC (e, "Error reading pixel data from image "
+                     "file \"" << fileName() << "\". " << e);
+        throw;
+    }
+}
+
+
+
 void
 InputFile::rawTileData (int &dx, int &dy,
 			int &lx, int &ly,

--- a/OpenEXR/IlmImf/ImfInputFile.h
+++ b/OpenEXR/IlmImf/ImfInputFile.h
@@ -201,7 +201,30 @@ class IMF_EXPORT InputFile : public GenericInputFile
     void		rawPixelData (int firstScanLine,
 				      const char *&pixelData,
 				      int &pixelDataSize);
-                                     
+
+
+    //----------------------------------------------
+    // Read a scanline's worth of raw pixel data 
+    // from the file, without uncompressing it, and 
+    // store in an external buffer, pixelData. 
+    // pixelData should be pre-allocated with space 
+    // for pixelDataSize chars. 
+    //
+    // This function can be used to separate the 
+    // reading of a raw scan line from the 
+    // decompression of that scan line, for
+    // example to allow multiple scan lines to be
+    // decompressed in parallel by an application's
+    // own threads, where it is not convenient to 
+    // use the threading within the library.
+    //----------------------------------------------
+
+    void		rawPixelDataToBuffer (int scanLine,
+					      char *pixelData,
+					      int &pixelDataSize) const;   
+    
+ 
+
     //--------------------------------------------------
     // Read a tile of raw pixel data from the file,
     // without uncompressing it (this function is

--- a/OpenEXR/IlmImf/ImfInputPart.cpp
+++ b/OpenEXR/IlmImf/ImfInputPart.cpp
@@ -104,6 +104,14 @@ InputPart::rawPixelData (int firstScanLine, const char *&pixelData, int &pixelDa
     file->rawPixelData(firstScanLine, pixelData, pixelDataSize);
 }
 
+
+void
+InputPart::rawPixelDataToBuffer (int scanLine, char *pixelData, int &pixelDataSize) const
+{
+    file->rawPixelDataToBuffer(scanLine, pixelData, pixelDataSize);
+}
+
+
 void
 InputPart::rawTileData (int &dx, int &dy, int &lx, int &ly,
              const char *&pixelData, int &pixelDataSize)

--- a/OpenEXR/IlmImf/ImfInputPart.h
+++ b/OpenEXR/IlmImf/ImfInputPart.h
@@ -66,7 +66,14 @@ class IMF_EXPORT InputPart
         void                rawPixelData (int firstScanLine,
                                           const char *&pixelData,
                                           int &pixelDataSize);
-        void                rawTileData (int &dx, int &dy,
+
+ 
+        void                rawPixelDataToBuffer (int scanLine,
+                                                  char *pixelData,
+                                                  int &pixelDataSize) const;
+
+
+       void                 rawTileData (int &dx, int &dy,
                                          int &lx, int &ly,
                                          const char *&pixelData,
                                          int &pixelDataSize);

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1699,4 +1699,38 @@ ScanLineInputFile::rawPixelData (int firstScanLine,
     }
 }
 
+
+void ScanLineInputFile::rawPixelDataToBuffer(int scanLine,
+                                             char *pixelData,
+                                             int &pixelDataSize) const
+{
+  if (_data->memoryMapped) {
+    throw IEX_NAMESPACE::ArgExc ("Reading raw pixel data to a buffer "
+                                 "is not supported for memory mapped "
+                                 "streams." );
+  }
+
+  try 
+  {
+    Lock lock (*_streamData);
+    
+    if (scanLine < _data->minY || scanLine > _data->maxY) 
+    {
+      throw IEX_NAMESPACE::ArgExc ("Tried to read scan line outside "
+                                   "the image file's data window.");
+    }
+    
+    readPixelData
+      (_streamData, _data, scanLine, pixelData, pixelDataSize);
+    
+  }
+  catch (IEX_NAMESPACE::BaseExc &e) 
+  {
+    REPLACE_EXC (e, "Error reading pixel data from image "
+                   "file \"" << fileName() << "\". " << e);
+    throw;
+  }
+}
+
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.h
@@ -184,6 +184,28 @@ class IMF_EXPORT ScanLineInputFile : public GenericInputFile
 				      const char *&pixelData,
 				      int &pixelDataSize);
 
+   
+    //----------------------------------------------
+    // Read a scanline's worth of raw pixel data 
+    // from the file, without uncompressing it, and 
+    // store in an external buffer, pixelData. 
+    // pixelData should be pre-allocated with space 
+    // for pixelDataSize chars. 
+    //
+    // This function can be used to separate the 
+    // reading of a raw scan line from the 
+    // decompression of that scan line, for
+    // example to allow multiple scan lines to be
+    // decompressed in parallel by an application's
+    // own threads, where it is not convenient to 
+    // use the threading within the library.
+    //----------------------------------------------
+
+    void                rawPixelDataToBuffer(int scanLine,
+					     char *pixelData,
+					     int &pixelDataSize) const;
+    
+  
     struct Data;
 
   private:


### PR DESCRIPTION
Adding rawPixelDataToBuffer() function for access to compressed data read from scanline input files.

Changes from The Foundry to add rawPixelDataToBuffer(...) function to the OpenEXR library. This allows you to read raw scan lines into an external buffer. It's similar to the existing function rawPixelData, but unlike this existing function it allows the user to control where the data will be stored instead of reading it into a local buffer. This means you can store multiple raw scan lines at once and enables the decompression of these scan lines to be done in parallel using an application's own threads.
(cherry picked from commit ca76ebb40a3c5a5c8e055f0c8d8be03ca52e91c8)