### PR TITLE
Fix for DEBUG pre-processor related issues in Xcode

### DIFF
--- a/Contrib/Photoshop/win32/EXRFormat.rc
+++ b/Contrib/Photoshop/win32/EXRFormat.rc
@@ -54,7 +54,7 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#ifdef _DEBUG
+#ifdef OPENEXR_DEBUG
 #include "tempDebug\EXRFormat.pipl"
 #else
 #include "tempRelease\EXRFormat.pipl"

--- a/Contrib/Photoshop/win32/EXRFormat.vcproj
+++ b/Contrib/Photoshop/win32/EXRFormat.vcproj
@@ -53,7 +53,7 @@
 				TargetMachine="1"/>
 			<Tool
 				Name="VCMIDLTool"
-				PreprocessorDefinitions="_DEBUG"
+				PreprocessorDefinitions="OPENEXR_DEBUG"
 				MkTypLibCompatible="TRUE"
 				SuppressStartupBanner="TRUE"
 				TargetEnvironment="1"
@@ -91,7 +91,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="0"
 				AdditionalIncludeDirectories="..\rsrc,..\src\framework,..\src\main,..\src\resample,..\src\ui,..\sdk\PhotoshopAPI\ADM,..\sdk\PhotoshopAPI\General,..\sdk\PhotoshopAPI\Photoshop,..\sdk\PhotoshopAPI\Pica_sp,..\sdk\PhotoshopAPI\Resources,..\sdk\PhotoshopUtils\Includes,..\..\OpenEXR\Half,..\..\OpenEXR\Iex,..\..\OpenEXR\Imath,..\..\OpenEXR\IlmImf"
-				PreprocessorDefinitions="_DEBUG;WIN32;_WINDOWS;MSWindows=1;ISOLATION_AWARE_ENABLED;PLATFORM_WIN32;WIN_ENV"
+				PreprocessorDefinitions="OPENEXR_DEBUG;WIN32;_WINDOWS;MSWindows=1;ISOLATION_AWARE_ENABLED;PLATFORM_WIN32;WIN_ENV"
 				RuntimeLibrary="2"
 				PrecompiledHeaderFile=""
 				AssemblerListingLocation=".\tempDebug/"
@@ -119,7 +119,7 @@
 				TargetMachine="1"/>
 			<Tool
 				Name="VCMIDLTool"
-				PreprocessorDefinitions="_DEBUG"
+				PreprocessorDefinitions="OPENEXR_DEBUG"
 				MkTypLibCompatible="TRUE"
 				SuppressStartupBanner="TRUE"
 				TargetEnvironment="1"
@@ -133,7 +133,7 @@
 				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
-				PreprocessorDefinitions="_DEBUG,MSWindows=1"
+				PreprocessorDefinitions="OPENEXR_DEBUG,MSWindows=1"
 				Culture="1033"/>
 			<Tool
 				Name="VCWebServiceProxyGeneratorTool"/>

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -374,7 +374,7 @@ unpack14 (const unsigned char b[14], unsigned short s[16])
     // Unpack a 14-byte block into 4 by 4 16-bit pixels.
     //
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 	assert (b[2] != 0xfc);
     #endif
 
@@ -420,7 +420,7 @@ unpack3 (const unsigned char b[3], unsigned short s[16])
     // Unpack a 3-byte block into 4 by 4 identical 16-bit pixels.
     //
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 	assert (b[2] == 0xfc);
     #endif
 
@@ -726,7 +726,7 @@ B44Compressor::compress (const char *inPtr,
 	    {
 		ChannelData &cd = _channelData[i];
 
-		#if defined (DEBUG)
+		#if defined (OPENEXR_DEBUG)
 		    assert (cd.type == HALF);
 		#endif
 
@@ -747,7 +747,7 @@ B44Compressor::compress (const char *inPtr,
     // and FLOAT channels are in Xdr format.
     //
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 
 	for (int i = 1; i < _numChans; ++i)
 	    assert (_channelData[i-1].end == _channelData[i].start);
@@ -1037,7 +1037,7 @@ B44Compressor::uncompress (const char *inPtr,
 	    {
 		ChannelData &cd = _channelData[i];
 
-		#if defined (DEBUG)
+		#if defined (OPENEXR_DEBUG)
 		    assert (cd.type == HALF);
 		#endif
 
@@ -1052,7 +1052,7 @@ B44Compressor::uncompress (const char *inPtr,
 	}
     }
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 
 	for (int i = 1; i < _numChans; ++i)
 	    assert (_channelData[i-1].end == _channelData[i].start);

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -332,7 +332,7 @@ writePixelData (OutputStreamMutex *filedata,
     partdata->lineOffsets[(partdata->currentScanLine - partdata->minY) / partdata->linesInBuffer] =
         currentPosition;
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 
         assert (filedata->os->tellp() == currentPosition);
 
@@ -1303,7 +1303,7 @@ DeepScanLineOutputFile::writePixels (int numScanLines)
                 _data->currentScanLine = _data->currentScanLine +
                                          step * numLines;
 
-                #ifdef DEBUG
+                #ifdef OPENEXR_DEBUG
 
                     assert (_data->currentScanLine ==
                             ((_data->lineOrder == INCREASING_Y) ?

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -422,7 +422,7 @@ DeepTiledOutputFile::Data::nextTileCoord (const TileCoord &a)
                         b.lx = 0;
                         b.ly++;
 
-                        #ifdef DEBUG
+                        #ifdef OPENEXR_DEBUG
                             assert (b.ly <= numYLevels);
                         #endif
                     }
@@ -466,7 +466,7 @@ DeepTiledOutputFile::Data::nextTileCoord (const TileCoord &a)
                         b.lx = 0;
                         b.ly++;
 
-                        #ifdef DEBUG
+                        #ifdef OPENEXR_DEBUG
                             assert (b.ly <= numYLevels);
                         #endif
                     }
@@ -517,7 +517,7 @@ writeTileData (DeepTiledOutputFile::Data *ofd,
 
     ofd->tileOffsets (dx, dy, lx, ly) = currentPosition;
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
         assert (ofd->_streamData->os->tellp() == currentPosition);
     #endif
 
@@ -744,7 +744,7 @@ convertToXdr (DeepTiledOutputFile::Data *ofd,
         }
     }
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 
         assert (writePtr == readPtr);
 
@@ -937,7 +937,7 @@ TileBufferTask::execute ()
                                              slice.yStride,
                                              _ofd->format,
                                              slice.type);
-#if defined(DEBUG)
+#if defined(OPENEXR_DEBUG)
                       assert(writePtr-_tileBuffer->buffer<=totalBytes);
 #endif
                 }

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -287,7 +287,7 @@ writePixelData (OutputStreamMutex *filedata,
     partdata->lineOffsets[(partdata->currentScanLine - partdata->minY) / partdata->linesInBuffer] =
         currentPosition;
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 
         assert (filedata->os->tellp() == currentPosition);
 
@@ -572,7 +572,7 @@ LineBufferTask::execute ()
             if (_lineBuffer->endOfLineBufferData < writePtr)
                 _lineBuffer->endOfLineBufferData = writePtr;
         
-            #ifdef DEBUG
+            #ifdef OPENEXR_DEBUG
         
                 assert (writePtr - (_lineBuffer->buffer +
                         _ofd->offsetInLineBuffer[y - _ofd->minY]) ==
@@ -1120,7 +1120,7 @@ OutputFile::writePixels (int numScanLines)
                 _data->currentScanLine = _data->currentScanLine +
                                          step * numLines;
     
-                #ifdef DEBUG
+                #ifdef OPENEXR_DEBUG
     
                     assert (_data->currentScanLine ==
                             ((_data->lineOrder == INCREASING_Y) ?

--- a/OpenEXR/IlmImf/ImfPizCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfPizCompressor.cpp
@@ -408,7 +408,7 @@ PizCompressor::compress (const char *inPtr,
 	}
     }
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 
 	for (int i = 1; i < _numChans; ++i)
 	    assert (_channelData[i-1].end == _channelData[i].start);
@@ -650,7 +650,7 @@ PizCompressor::uncompress (const char *inPtr,
 	}
     }
 
-    #if defined (DEBUG)
+    #if defined (OPENEXR_DEBUG)
 
 	for (int i = 1; i < _numChans; ++i)
 	    assert (_channelData[i-1].end == _channelData[i].start);

--- a/OpenEXR/IlmImf/ImfRgbaYca.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaYca.cpp
@@ -135,7 +135,7 @@ decimateChromaHoriz (int n,
 		     const Rgba ycaIn[/*n+N-1*/],
 		     Rgba ycaOut[/*n*/])
 {
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 	assert (ycaIn != ycaOut);
     #endif
 
@@ -259,7 +259,7 @@ reconstructChromaHoriz (int n,
 			const Rgba ycaIn[/*n+N-1*/],
 			Rgba ycaOut[/*n*/])
 {
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 	assert (ycaIn != ycaOut);
     #endif
 

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -368,7 +368,7 @@ TiledOutputFile::Data::nextTileCoord (const TileCoord &a)
                         b.lx = 0;
                         b.ly++;
 
-			#ifdef DEBUG
+			#ifdef OPENEXR_DEBUG
 			    assert (b.ly <= numYLevels);
 			#endif
                     }
@@ -413,7 +413,7 @@ TiledOutputFile::Data::nextTileCoord (const TileCoord &a)
                         b.lx = 0;
                         b.ly++;
 
-			#ifdef DEBUG
+			#ifdef OPENEXR_DEBUG
 			    assert (b.ly <= numYLevels);
 			#endif
                     }
@@ -457,7 +457,7 @@ writeTileData (OutputStreamMutex *streamData,
 
     ofd->tileOffsets (dx, dy, lx, ly) = currentPosition;
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 	assert (streamData->os->tellp() == currentPosition);
     #endif
 
@@ -646,7 +646,7 @@ convertToXdr (TiledOutputFile::Data *ofd,
 	}
     }
 
-    #ifdef DEBUG
+    #ifdef OPENEXR_DEBUG
 
 	assert (writePtr == readPtr);
 


### PR DESCRIPTION
### Issue:

In Xcode when building a Debug targeted project the IDE adds `-DEBUG` to the target. This is causing many errors for libraries that use OpenEXR in it's release form and include headers which expose these parts of OpenEXR when that `-DEBUG` command is turned on (default action).
### Proposed change:

Swap out : `DEBUG` to `OPENEXR_DEBUG`
