### PR TITLE
Fixed memory corruption / actual crashes on Window

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -91,6 +91,12 @@ class SimdAlignedBuffer64
             memcpy (_buffer, rhs._buffer, 64 * sizeof (T));
         }
 
+        SimdAlignedBuffer64 &operator=(const SimdAlignedBuffer64 &rhs)
+        {
+            memcpy (_buffer, rhs._buffer, 64 * sizeof (T));
+            return *this;
+        }
+
         ~SimdAlignedBuffer64 ()
         {
             EXRFreeAligned (_handle);


### PR DESCRIPTION
Fixed memory corruption caused by missing assignment operator with non-trivial copy constructor logic.
FIxes crashes on Windows when "dwaa" or "dwab" codecs are used for saving files.
