### PR TITLE
Switch AVX detection asm to not use an empty clobber list for use with older gcc versions

### DIFF
--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -188,7 +188,7 @@ AC_COMPILE_IFELSE(
                  __asm__(
                      "xgetbv     \n"
                      "vzeroupper  "
-                     : "=a"(eax), "=d"(edx) : "c"(n) : );
+                     : "=a"(eax), "=d"(edx) : "c"(n));
              #else
                  #error No GCC style inline asm supported for AVX instructions
              #endif


### PR DESCRIPTION
So it looks like older gcc versions don't like empty clobber lists resulting in an error during configure:

conftest.c:45: error: expected string literal before ')' token

so it is not really testing if we have AVX instructions but the syntax of the version of gcc we have.

This appears to fix it. In particular gcc 4.1.2  for current Nuke

Kevin