### PR TITLE
Bug fix in ThreadPool -- holding lock when not needed

### DIFF
--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -430,6 +430,8 @@ ThreadPool::addTask (Task* task)
 
     if (_data->numThreads == 0)
     {
+        // run the task ourselves, don't keep holding the threadMutex
+        lock.release ();
         task->execute ();
         delete task;
     }


### PR DESCRIPTION
ThreadPool::addTask should not keep holding the lock when executing the task with the calling thread. This inadvertently will block any other threads reading or writing exr files concurrently.
