### PR TITLE
Fix copy and paste bug

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepTiledInputPart.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputPart.cpp
@@ -90,7 +90,7 @@ DeepTiledInputPart::isComplete () const
 unsigned int
 DeepTiledInputPart::tileXSize () const
 {
-    return file->isComplete();
+    return file->tileXSize();
 }
 
 


### PR DESCRIPTION
The implementation of DeepTiledInputPart::tileXSize was copy and pasted from the function above but not changed. This causes it to return incorrect values.