### PR TITLE
fix potential io streams leak

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -836,6 +836,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
+        delete _data->_streamData->os;
         delete _data->_streamData;
         delete _data;
 
@@ -845,6 +846,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile
     }
     catch (...)
     {
+        delete _data->_streamData->os;
         delete _data->_streamData;
         delete _data;
         throw;

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -137,6 +137,7 @@ MultiPartInputFile::MultiPartInputFile(const char fileName[],
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
+        delete _data->is;
         delete _data;
 
         REPLACE_EXC (e, "Cannot read image file "
@@ -145,6 +146,7 @@ MultiPartInputFile::MultiPartInputFile(const char fileName[],
     }
     catch (...)
     {
+        delete _data->is;
         delete _data;
         throw;
     }

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
@@ -226,6 +226,7 @@ MultiPartOutputFile::MultiPartOutputFile (const char fileName[],
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
+        delete _data->os;
         delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
@@ -234,6 +235,7 @@ MultiPartOutputFile::MultiPartOutputFile (const char fileName[],
     }
     catch (...)
     {
+        delete _data->os;
         delete _data;
         throw;
     }

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -678,8 +678,9 @@ OutputFile::OutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-	if (_data)       delete _data;
+        delete _data->_streamData->os;
+        delete _data->_streamData;
+        delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
 			"\"" << fileName << "\". " << e);
@@ -687,8 +688,9 @@ OutputFile::OutputFile
     }
     catch (...)
     {
-        if (_data && _data->_streamData) delete _data->_streamData;
-        if (_data)       delete _data;
+        delete _data->_streamData->os;
+        delete _data->_streamData;
+	delete _data;
 
         throw;
     }

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -876,6 +876,7 @@ TiledOutputFile::TiledOutputFile
     }
     catch (IEX_NAMESPACE::BaseExc &e)
     {
+        delete _streamData->os;
         delete _streamData;
 	delete _data;
 
@@ -885,6 +886,7 @@ TiledOutputFile::TiledOutputFile
     }
     catch (...)
     {
+        delete _streamData->os;
         delete _streamData;
 	delete _data;
         throw;


### PR DESCRIPTION
Io streams/memory leak can happen in case of any exceptions during further initialization.
