### PR TITLE
Mingw: Fix fstream usage for filenames with UTF-8 encoding 

### DIFF
--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -259,6 +259,7 @@ INSTALL ( FILES
   ImfDeepImageState.h
   ImfDeepImageStateAttribute.h
   ImfFloatVectorAttribute.h
+  fstream_mingw.h
   DESTINATION
   ${CMAKE_INSTALL_PREFIX}/include/OpenEXR
 )

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -80,7 +80,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ifstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -75,7 +75,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -81,7 +81,6 @@ using IMATH_NAMESPACE::Box2i;
 using IMATH_NAMESPACE::V2i;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::map;
 using std::min;
 using std::max;

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -77,7 +77,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -73,7 +73,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ifstream;
 using std::min;
 using std::max;
 using std::sort;

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -79,7 +79,6 @@ using IMATH_NAMESPACE::Box2i;
 using IMATH_NAMESPACE::V2i;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::map;
 using std::min;
 using std::max;

--- a/OpenEXR/IlmImf/fstream_mingw.h
+++ b/OpenEXR/IlmImf/fstream_mingw.h
@@ -1,0 +1,357 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2004, Industrial Light & Magic, a division of Lucas
+// Digital Ltd. LLC
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Industrial Light & Magic nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////
+
+
+/// @file  fstream_mingw.h
+///
+/// @brief Utilities for dealing with fstream on MingW.
+/// Basically accepting wchar_t* filenames in the std::ifstream::open function
+/// is a Windows MSVC extension and does not work on MingW. This file implements
+/// ifstream and ofstream so that they work with UTF-8 filenames.
+
+
+#ifndef INCLUDED_IMF_FSTREAM_MINGW_H
+#define INCLUDED_IMF_FSTREAM_MINGW_H
+
+#include <cassert>
+#include <istream>
+#include <ostream>
+
+#if defined(_WIN32) && defined(__GLIBCXX__)
+#include <ext/stdio_filebuf.h> // __gnu_cxx::stdio_filebuf
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <Share.h>
+
+#include "ImfNamespace.h"
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
+
+template <class _CharT, class _Traits = std::char_traits<_CharT> >
+class basic_ifstream
+: public std::basic_istream<_CharT, _Traits>
+{
+public:
+    typedef _CharT                         char_type;
+    typedef _Traits                        traits_type;
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+    
+    typedef typename __gnu_cxx::stdio_filebuf<char_type, traits_type> stdio_filebuf;
+
+    
+    basic_ifstream();
+    explicit basic_ifstream(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::in);
+    
+    virtual ~basic_ifstream();
+    
+    stdio_filebuf* rdbuf() const;
+    bool is_open() const;
+    void open(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::in);
+    void close();
+    
+private:
+    
+    void open_internal(const std::wstring& path, std::ios_base::openmode mode);
+    
+    stdio_filebuf* __sb_;
+};
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::basic_ifstream()
+: std::basic_istream<char_type, traits_type>(0)
+, __sb_(0)
+{
+}
+
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::basic_ifstream(const std::wstring& path, std::ios_base::openmode __mode)
+: std::basic_istream<char_type, traits_type>(0)
+, __sb_(0)
+{
+    open_internal(path, __mode | std::ios_base::in);
+}
+
+template <class _CharT, class _Traits>
+inline
+basic_ifstream<_CharT, _Traits>::~basic_ifstream()
+{
+    delete __sb_;
+}
+
+
+inline int
+ios_open_mode_to_oflag(std::ios_base::openmode mode)
+{
+    int f = 0;
+    if (mode & std::ios_base::in) {
+        f |= _O_RDONLY;
+    }
+    if (mode & std::ios_base::out) {
+        f |= _O_WRONLY;
+        f |= _O_CREAT;
+        if (mode & std::ios_base::app) {
+            f |= _O_APPEND;
+        }
+        if (mode & std::ios_base::trunc) {
+            f |= _O_TRUNC;
+        }
+    }
+    if (mode & std::ios_base::binary) {
+        f |= _O_BINARY;
+    } else {
+        f |= _O_TEXT;
+    }
+    return f;
+}
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ifstream<_CharT, _Traits>::open_internal(const std::wstring& path, std::ios_base::openmode mode)
+{
+	if (is_open()) {
+		// if the stream is already associated with a file (i.e., it is already open), calling this function fails.
+		this->setstate(std::ios_base::failbit);
+        return;
+	}
+    int fd;
+    int oflag = ios_open_mode_to_oflag(mode);
+    errno_t errcode = _wsopen_s(&fd, path.c_str(), oflag, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+    if (errcode != 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+    __sb_ = new stdio_filebuf(fd, mode, 1);
+    if (__sb_ == 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+	// 409. Closing an fstream should clear error state
+    this->clear();
+	assert(__sb_);
+	
+	// In init() the rdstate() is set to badbit if __sb_ is NULL and
+	// goodbit otherwise. The assert afterwards ensures this.
+    this->init(__sb_);
+	assert(this->good() && !this->fail());
+}
+
+template <class _CharT, class _Traits>
+inline
+typename basic_ifstream<_CharT, _Traits>::stdio_filebuf*
+basic_ifstream<_CharT, _Traits>::rdbuf() const
+{
+    return const_cast<stdio_filebuf*>(__sb_);
+}
+
+
+template <class _CharT, class _Traits>
+inline
+bool
+basic_ifstream<_CharT, _Traits>::is_open() const
+{
+    return __sb_ && __sb_->is_open();
+}
+
+
+template <class _CharT, class _Traits>
+void
+basic_ifstream<_CharT, _Traits>::open(const std::wstring& path, std::ios_base::openmode __mode)
+{
+    open_internal(path, __mode | std::ios_base::in);
+}
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ifstream<_CharT, _Traits>::close()
+{
+    if (!__sb_) {
+        return;
+    }
+    if (__sb_->close() == 0)
+        this->setstate(std::ios_base::failbit);
+    
+    delete __sb_;
+	__sb_= 0;
+
+}
+
+
+
+template <class _CharT, class _Traits = std::char_traits<_CharT> >
+class basic_ofstream
+: public std::basic_ostream<_CharT, _Traits>
+{
+public:
+    typedef _CharT                         char_type;
+    typedef _Traits                        traits_type;
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+    
+    typedef typename __gnu_cxx::stdio_filebuf<char_type, traits_type> stdio_filebuf;
+    
+    
+    basic_ofstream();
+    explicit basic_ofstream(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::out);
+    
+    virtual ~basic_ofstream();
+    
+    stdio_filebuf* rdbuf() const;
+    bool is_open() const;
+    void open(const std::wstring& path, std::ios_base::openmode __mode = std::ios_base::out);
+    void close();
+    
+private:
+    
+    void open_internal(const std::wstring& path, std::ios_base::openmode mode);
+    
+    stdio_filebuf* __sb_;
+};
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::basic_ofstream()
+: std::basic_ostream<char_type, traits_type>(0)
+, __sb_(0)
+{
+}
+
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::basic_ofstream(const std::wstring& path, std::ios_base::openmode __mode)
+: std::basic_ostream<char_type, traits_type>(0)
+, __sb_(0)
+{
+    open_internal(path, __mode  | std::ios_base::out);
+}
+
+template <class _CharT, class _Traits>
+inline
+basic_ofstream<_CharT, _Traits>::~basic_ofstream()
+{
+    delete __sb_;
+}
+
+
+template <class _CharT, class _Traits>
+inline
+void
+basic_ofstream<_CharT, _Traits>::open_internal(const std::wstring& path, std::ios_base::openmode mode)
+{
+	if (is_open()) {
+		// if the stream is already associated with a file (i.e., it is already open), calling this function fails.
+		this->setstate(std::ios_base::failbit);
+        return;
+	}
+    int fd;
+    int oflag = ios_open_mode_to_oflag(mode);
+    errno_t errcode = _wsopen_s(&fd, path.c_str(), oflag, _SH_DENYNO, _S_IREAD | _S_IWRITE);
+    if (errcode != 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+    __sb_ = new stdio_filebuf(fd, mode, 1);
+    if (__sb_ == 0) {
+        this->setstate(std::ios_base::failbit);
+        return;
+    }
+	// 409. Closing an fstream should clear error state
+    this->clear();
+	assert(__sb_);
+	
+	// In init() the rdstate() is set to badbit if __sb_ is NULL and
+	// goodbit otherwise. The assert afterwards ensures this.
+    this->init(__sb_);
+	assert(this->good() && !this->fail());
+}
+
+
+template <class _CharT, class _Traits>
+inline
+typename basic_ofstream<_CharT, _Traits>::stdio_filebuf*
+basic_ofstream<_CharT, _Traits>::rdbuf() const
+{
+    return const_cast<stdio_filebuf*>(__sb_);
+}
+
+
+
+template <class _CharT, class _Traits>
+inline
+bool
+basic_ofstream<_CharT, _Traits>::is_open() const
+{
+    return __sb_ && __sb_->is_open();
+}
+
+
+template <class _CharT, class _Traits>
+void
+basic_ofstream<_CharT, _Traits>::open(const std::wstring& path, std::ios_base::openmode __mode)
+{
+    open_internal(path, __mode | std::ios_base::out);
+}
+
+template <class _CharT, class _Traits>
+inline 
+void
+basic_ofstream<_CharT, _Traits>::close()
+{
+    if (!__sb_) {
+        return;
+    }
+    if (__sb_->close() == 0)
+        this->setstate(std::ios_base::failbit);
+    
+    delete __sb_;
+	__sb_= 0;
+}
+// basic_fstream
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+
+#endif // #if defined(_WIN32) && defined(__GLIBCXX__)
+
+
+#endif // INCLUDED_IMF_FSTREAM_MINGW_H

--- a/OpenEXR/IlmImfTest/testMagic.cpp
+++ b/OpenEXR/IlmImfTest/testMagic.cpp
@@ -46,7 +46,6 @@
 
 
 using namespace OPENEXR_IMF_NAMESPACE;
-using namespace std;
 
 
 namespace {
@@ -54,9 +53,14 @@ namespace {
 void
 testFile1 (const char fileName[], bool isImfFile)
 {
-    cout << fileName << " " << flush;
+    std::cout << fileName << " " << std::flush;
 
-    ifstream f (fileName, ios_base::binary);
+#ifdef _WIN32
+	std::wstring filenameStr = StrUtils::utf8_to_utf16(std::string(fileName));
+#else
+	std::string filenameStr(fileName);
+#endif
+    OPENEXR_IMF_INTERNAL_NAMESPACE::ifstream f (filenameStr, std::ios_base::binary);
     assert (!!f);
 
     char bytes[4];
@@ -64,14 +68,14 @@ testFile1 (const char fileName[], bool isImfFile)
 
     assert (!!f && isImfFile == isImfMagic (bytes));
 
-    cout << "is " << (isImfMagic (bytes)? "": "not ") << "an OpenEXR file\n";
+    std::cout << "is " << (isImfMagic (bytes)? "": "not ") << "an OpenEXR file\n";
 }
 
 
 void
 testFile2 (const char fileName[], bool exists, bool exrFile, bool tiledFile)
 {
-    cout << fileName << " " << flush;
+    std::cout << fileName << " " << std::flush;
 
     bool exr, tiled;
 
@@ -107,9 +111,9 @@ testFile2 (const char fileName[], bool exists, bool exrFile, bool tiledFile)
 	    assert (is.tellg() == 0);
     }
 
-    cout << (exists? "exists": "does not exist") << ", " <<
+    std::cout << (exists? "exists": "does not exist") << ", " <<
 	    (exrFile? "is an OpenEXR file": "is not an OpenEXR file") << ", " <<
-	    (tiledFile? "is tiled": "is not tiled") << endl;
+	    (tiledFile? "is tiled": "is not tiled") << std::endl;
 }
 
 } // namespace
@@ -120,7 +124,7 @@ testMagic (const std::string &)
 {
     try
     {
-	cout << "Testing magic number" << endl;
+	std::cout << "Testing magic number" << std::endl;
 
 	testFile1 (ILM_IMF_TEST_IMAGEDIR "comp_none.exr", true);
 	testFile1 (ILM_IMF_TEST_IMAGEDIR "invalid.exr", false);
@@ -130,11 +134,11 @@ testMagic (const std::string &)
 	testFile2 (ILM_IMF_TEST_IMAGEDIR "invalid.exr", true, false, false);
 	testFile2 (ILM_IMF_TEST_IMAGEDIR "does_not_exist.exr", false, false, false);
 
-	cout << "ok\n" << endl;
+	std::cout << "ok\n" << std::endl;
     }
     catch (const std::exception &e)
     {
-	cerr << "ERROR -- caught exception: " << e.what() << endl;
+	std::cerr << "ERROR -- caught exception: " << e.what() << std::endl;
 	assert (false);
     }
 }

--- a/OpenEXR/IlmImfTest/testPreviewImage.cpp
+++ b/OpenEXR/IlmImfTest/testPreviewImage.cpp
@@ -33,6 +33,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 
+#include <ImfStdIO.h>
 #include <ImfRgbaFile.h>
 #include <ImfArray.h>
 #include <ImfPreviewImage.h>
@@ -46,7 +47,6 @@
 
 
 using namespace OPENEXR_IMF_NAMESPACE;
-using namespace std;
 using namespace IMATH_NAMESPACE;
 
 
@@ -77,7 +77,7 @@ readWriteFiles (const char fileName1[],
     // the files are identical.
     //
 
-    cout << "reading file " << fileName1 << endl;
+    std::cout << "reading file " << fileName1 << std::endl;
 
     RgbaInputFile file1 (fileName1);
 
@@ -94,7 +94,7 @@ readWriteFiles (const char fileName1[],
     file1.setFrameBuffer (pixels1 - dx - dy * w, 1, w);
     file1.readPixels (dw.min.y, dw.max.y);
 
-    cout << "generating preview image" << endl;
+    std::cout << "generating preview image" << std::endl;
 
     const int PREVIEW_WIDTH  = 128;
     const int PREVIEW_HEIGHT = 64;
@@ -105,7 +105,7 @@ readWriteFiles (const char fileName1[],
 	for (int x = 0; x < PREVIEW_WIDTH; ++x)
 	    preview1.pixel (x, y) = PreviewRgba (x*2, y*4, x+y, 128);
 
-    cout << "writing file " << fileName2 << endl;
+    std::cout << "writing file " << fileName2 << std::endl;
 
     {
 	Header header (file1.header());
@@ -118,7 +118,7 @@ readWriteFiles (const char fileName1[],
 	    file2.writePixels (1);
     }
 
-    cout << "reading file " << fileName2 << endl;
+    std::cout << "reading file " << fileName2 << std::endl;
 
     {
 	RgbaInputFile file2 (fileName2);
@@ -155,7 +155,7 @@ readWriteFiles (const char fileName1[],
 	}
     }
 
-    cout << "writing file " << fileName3 << endl;
+    std::cout << "writing file " << fileName3 << std::endl;
 
     {
 	Header header (file1.header());
@@ -173,11 +173,18 @@ readWriteFiles (const char fileName1[],
 	}
     }
 
-    cout << "comparing files " << fileName2 << " and " << fileName3 << endl;
+    std::cout << "comparing files " << fileName2 << " and " << fileName3 << std::endl;
 
     {
-	ifstream file2 (fileName2, std::ios_base::binary);
-	ifstream file3 (fileName3, std::ios_base::binary);
+#ifdef _WIN32
+	std::wstring filename2Str = StrUtils::utf8_to_utf16(std::string(fileName2));
+	std::wstring filename3Str = StrUtils::utf8_to_utf16(std::string(fileName3));
+#else
+	std::string filename2Str(fileName2);
+	std::string filename3Str(fileName3);
+#endif
+	OPENEXR_IMF_INTERNAL_NAMESPACE::ifstream file2 (filename2Str, std::ios_base::binary);
+	OPENEXR_IMF_INTERNAL_NAMESPACE::ifstream file3 (filename3Str, std::ios_base::binary);
 
 	while (true)
 	{
@@ -207,17 +214,17 @@ testPreviewImage (const std::string &tempDir)
 
     try
     {
-	cout << "Testing preview image attribute" << endl;
+	std::cout << "Testing preview image attribute" << std::endl;
 
 	readWriteFiles (ILM_IMF_TEST_IMAGEDIR "comp_piz.exr",
 			filename1.c_str(),
 			filename2.c_str());
 
-	cout << "ok\n" << endl;
+	std::cout << "ok\n" << std::endl;
     }
     catch (const std::exception &e)
     {
-	cerr << "ERROR -- caught exception: " << e.what() << endl;
+	std::cerr << "ERROR -- caught exception: " << e.what() << std::endl;
 	assert (false);
     }
 }


### PR DESCRIPTION
On Windows, filenames with UTF-8 encoding, needs to be converted to UTF-16 with _MultiByteToWideChar (CP_UTF8_ so that files with filename containing characters other than ASCII can be read correctly.

On MSVC, there's a non-standard extension that adds a constructor of **std::ifstream** and **std::ofstream** so that they take a **std::wstring** in parameter. 

On MingW, using GCC, there's no such constructor.

According to http://stackoverflow.com/questions/6524821/opening-stream-via-function the only way to fix UTF-8 filenames on Windows when compiling with GCC is to use **__gnu_cxx::stdio_filebuf**.
The problem is, according to the STL documentation: _the destructor of istream and ostream does not destroy nor performs any operations on the associated stream buffer object._

In order to not modify the A.P.I for other platform, the only solution is to make a new implementation of _ifstream_ and _ostream_ that actually embeds a **__gnu_cxx::stdio_filebuf** and destroys it.

This has been placed in OpenEXR/IlmImf/fstream_mingw.h

As seen in IlmStdio.h, _ifstream_ and _ostream_ are now part of the internal OpenEXR namespace, so one must ensure not using things such as::

```
using std::ifstream;
using std::ofstream;
using namespace std;
```

when  using ifstream or ofstream.

See pull-request made on OpenImageIO that had the same issue: 

https://github.com/OpenImageIO/oiio/pull/1353
https://github.com/OpenImageIO/oiio/pull/1366

Alex
