### PR TITLE
Add missing OpenEXR headers to CMake install rule

### DIFF
--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -259,6 +259,29 @@ INSTALL ( FILES
   ImfDeepImageState.h
   ImfDeepImageStateAttribute.h
   ImfFloatVectorAttribute.h
+  ImfAutoArray.h
+  ImfCheckedArithmetic.h
+  ImfCompressor.h
+  ImfDwaCompressor.h
+  ImfDwaCompressorSimd.h
+  ImfFastHuf.h
+  ImfInputPartData.h
+  ImfInputStreamMutex.h
+  ImfOptimizedPixelReading.h
+  ImfOutputPartData.h
+  ImfOutputStreamMutex.h
+  ImfPizCompressor.h
+  ImfPxr24Compressor.h
+  ImfRle.h
+  ImfRleCompressor.h
+  ImfScanLineInputFile.h
+  ImfSimd.h
+  ImfStdIO.h
+  ImfSystemSpecific.h
+  ImfTiledMisc.h
+  ImfTileOffsets.h
+  ImfZip.h
+  ImfZipCompressor.h
   DESTINATION
   ${CMAKE_INSTALL_PREFIX}/include/OpenEXR
 )


### PR DESCRIPTION
This is semi-in response to https://github.com/openexr/openexr/issues/129 (we're having similar issues with our CMake-based build/package).

The header of particular interest is `ImfStdIO.h`, but I unless there's a specific reason not to, I don't see why not just include all of the header files in the installation. However, I'm very much not an expert on OpenEXR.