### PR TITLE
CMake enhancements to speed up "dependency builds" of OpenEXR.

### DIFF
--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -32,6 +32,8 @@ INCLUDE ( CPack )
 OPTION (BUILD_SHARED_LIBS    "Build Shared Libraries" ON)
 OPTION (USE_ZLIB_WINAPI      "Use ZLib Win API"       OFF)
 OPTION (NAMESPACE_VERSIONING "Use Namespace Versioning" ON)
+OPTION (BUILD_UTILS "Build the binary/utility programs" ON)
+OPTION (BUILD_TESTS "Build the tests" ON)
 
 # Setup osx rpathing
 SET (CMAKE_MACOSX_RPATH 1)
@@ -198,21 +200,25 @@ ADD_SUBDIRECTORY ( IlmImfExamples )
 ##########################
 # Tests
 ##########################
-ADD_SUBDIRECTORY ( IlmImfTest )
-ADD_SUBDIRECTORY ( IlmImfUtilTest )
-ADD_SUBDIRECTORY ( IlmImfFuzzTest )
+if (BUILD_TESTS)
+  ADD_SUBDIRECTORY ( IlmImfTest )
+  ADD_SUBDIRECTORY ( IlmImfUtilTest )
+  ADD_SUBDIRECTORY ( IlmImfFuzzTest )
+endif ()
 
 
 ##########################
 # Binaries / Utilities
 ##########################
-ADD_SUBDIRECTORY ( exrheader )
-ADD_SUBDIRECTORY ( exrmaketiled )
-ADD_SUBDIRECTORY ( exrstdattr )
-ADD_SUBDIRECTORY ( exrmakepreview )
-ADD_SUBDIRECTORY ( exrenvmap )
-ADD_SUBDIRECTORY ( exrmultiview )
-ADD_SUBDIRECTORY ( exrmultipart )
+if (BUILD_UTILS)
+  ADD_SUBDIRECTORY ( exrheader )
+  ADD_SUBDIRECTORY ( exrmaketiled )
+  ADD_SUBDIRECTORY ( exrstdattr )
+  ADD_SUBDIRECTORY ( exrmakepreview )
+  ADD_SUBDIRECTORY ( exrenvmap )
+  ADD_SUBDIRECTORY ( exrmultiview )
+  ADD_SUBDIRECTORY ( exrmultipart )
+endif ()
 
 
 ##########################

--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -2,39 +2,47 @@
 
 SET(CMAKE_INCLUDE_CURRENT_DIR 1)
 
-ADD_EXECUTABLE ( b44ExpLogTable
-  b44ExpLogTable.cpp
-)
+if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h")
+  ADD_EXECUTABLE ( b44ExpLogTable
+    b44ExpLogTable.cpp
+  )
+  
+  TARGET_LINK_LIBRARIES ( b44ExpLogTable
+    Half
+    Iex${ILMBASE_LIBSUFFIX}
+    IlmThread${ILMBASE_LIBSUFFIX}
+    ${PTHREAD_LIB}
+  )
+  
+  ADD_CUSTOM_COMMAND (
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/b44ExpLogTable >   ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
+    DEPENDS b44ExpLogTable
+  )
+else ()
+ message (STATUS "Skipping build of b44ExpLogTable.h")
+endif ()
 
-TARGET_LINK_LIBRARIES ( b44ExpLogTable
-  Half
-  Iex${ILMBASE_LIBSUFFIX}
-  IlmThread${ILMBASE_LIBSUFFIX}
-  ${PTHREAD_LIB}
-)
-
-ADD_CUSTOM_COMMAND (
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
-  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/b44ExpLogTable > ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
-  DEPENDS b44ExpLogTable
-)
-
-ADD_EXECUTABLE ( dwaLookups
-  dwaLookups.cpp
-)
-
-TARGET_LINK_LIBRARIES ( dwaLookups
-  Half
-  Iex${ILMBASE_LIBSUFFIX}
-  IlmThread${ILMBASE_LIBSUFFIX}
-  ${PTHREAD_LIB}
-)
-
-ADD_CUSTOM_COMMAND (
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
-  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/dwaLookups > ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
-  DEPENDS dwaLookups
-)
+if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h")
+  ADD_EXECUTABLE ( dwaLookups
+    dwaLookups.cpp
+  )
+  
+  TARGET_LINK_LIBRARIES ( dwaLookups
+    Half
+    Iex${ILMBASE_LIBSUFFIX}
+    IlmThread${ILMBASE_LIBSUFFIX}
+    ${PTHREAD_LIB}
+  )
+  
+  ADD_CUSTOM_COMMAND (
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/dwaLookups >   ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
+    DEPENDS dwaLookups
+  )
+else ()
+ message (STATUS "Skipping build of dwaLookups.h")
+endif ()
 
 SET ( ILMIMF_SRCS
   ImfAttribute.cpp


### PR DESCRIPTION
Sometimes, you build the OpenEXR project just to get the libraries that
are dependencies for other projects, and you want the process to be as
fast as possible. This patch helps in three ways:
- BUILD_UTILS option (default=ON) can be turned off to skip the building
  of the utility binaries such as exrheader, exrmaketiled, etc.
- BUILD_TESTS option (default=ON) can be turned off to skip everything
  in the IlmImfTest, IlmImfUtilTest, and IlmImfFuzzTest directories.
- If the b44ExpLogTable.h and/or dwaLookups.h files happen to magically
  be found in their designated place, those will be used rather than
  rebuilt anew (which can take a LONG time on a slow one-core build-bot).

This is a first step, and only for people using CMake. I have not tried
to do any of the equivalents for the "./configure" crowd (I lack both
the knowledge and time to do it right). Also, probably a better long-term
approach on those header files is to just commit the built ones into the
source repo, so it never needs to build it anew (except perhaps as a
special testing mode).
