### PR TITLE
Remove deprecated "register" keyword from half.h

### DIFF
--- a/IlmBase/Half/half.h
+++ b/IlmBase/Half/half.h
@@ -459,7 +459,7 @@ half::half (float f)
 	// to do the float-to-half conversion.
 	//
 
-	register int e = (x.i >> 23) & 0x000001ff;
+	int e = (x.i >> 23) & 0x000001ff;
 
 	e = _eLut[e];
 
@@ -470,7 +470,7 @@ half::half (float f)
 	    // bits and combine it with the sign and exponent.
 	    //
 
-	    register int m = x.i & 0x007fffff;
+	    int m = x.i & 0x007fffff;
 	    _h = e + ((m + 0x00000fff + ((m >> 13) & 1)) >> 13);
 	}
 	else


### PR DESCRIPTION
The "register" keyword is deprecated and is ignored by modern compilers.  It is causing compiler warning spam in C++11 projects that use OpenEXR.  This commit removes the offending two occurrences.

Thanks!