### PR TITLE
m4/path.pkgconfig.m4: use PKG_PROG_PKG_CONFIG to find correct pkg-config

### DIFF
--- a/OpenEXR/m4/path.pkgconfig.m4
+++ b/OpenEXR/m4/path.pkgconfig.m4
@@ -50,8 +50,7 @@ TEST_LIBS=""
 AC_ARG_WITH(arg_test_prefix,[  --with-arg_test_prefix=PFX  Prefix where tested libraries are supposed to be installed (optional)], test_prefix="$withval", test_prefix="NONE")
 echo "test_prefix = $test_prefix"
 
-AC_ARG_VAR(PKG_CONFIG, Path to pkg-config command)
-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+PKG_PROG_PKG_CONFIG
 AC_ARG_WITH(pkg-config,[  --with-pkg-config=PATH Specify which pkg-config to use (optional)], PKG_CONFIG="$withval",)
 
 


### PR DESCRIPTION
pkg-config supplies this macro and prefers it to be used to allow for
cross-compilation scenarios where target-prefixed binaries are prefered
to pkg-config
