### PR TITLE
Windows compile fix

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -51,6 +51,8 @@
 #include <half.h>
 #include <assert.h>
 
+#include <algorithm>
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
 #define _SSE_ALIGNMENT        32


### PR DESCRIPTION
std::min wasn't found due to "algorithm" not being included.