### PR TITLE
Remove 'register' keyword.

### DIFF
--- a/IlmBase/Half/half.cpp
+++ b/IlmBase/Half/half.cpp
@@ -94,9 +94,9 @@ half::convert (int i)
     // of float and half (127 versus 15).
     //
 
-    register int s =  (i >> 16) & 0x00008000;
-    register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-    register int m =   i        & 0x007fffff;
+    int s =  (i >> 16) & 0x00008000;
+    int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+    int m =   i        & 0x007fffff;
 
     //
     // Now reassemble s, e and m into a half:

--- a/IlmBase/Half/half.h
+++ b/IlmBase/Half/half.h
@@ -459,7 +459,7 @@ half::half (float f)
 	// to do the float-to-half conversion.
 	//
 
-	register int e = (x.i >> 23) & 0x000001ff;
+	int e = (x.i >> 23) & 0x000001ff;
 
 	e = _eLut[e];
 
@@ -470,7 +470,7 @@ half::half (float f)
 	    // bits and combine it with the sign and exponent.
 	    //
 
-	    register int m = x.i & 0x007fffff;
+	    int m = x.i & 0x007fffff;
 	    _h = e + ((m + 0x00000fff + ((m >> 13) & 1)) >> 13);
 	}
 	else

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -2527,11 +2527,11 @@ Matrix44<T>::multiply (const Matrix44<T> &a,
                        const Matrix44<T> &b,
                        Matrix44<T> &c)
 {
-    register const T * IMATH_RESTRICT ap = &a.x[0][0];
-    register const T * IMATH_RESTRICT bp = &b.x[0][0];
-    register       T * IMATH_RESTRICT cp = &c.x[0][0];
+    const T * IMATH_RESTRICT ap = &a.x[0][0];
+    const T * IMATH_RESTRICT bp = &b.x[0][0];
+          T * IMATH_RESTRICT cp = &c.x[0][0];
 
-    register T a0, a1, a2, a3;
+    T a0, a1, a2, a3;
 
     a0 = ap[0];
     a1 = ap[1];


### PR DESCRIPTION
'register' is a relic of K&R-era C, it's utterly useless in modern compilers.  It's been deprecated in C++11, and therefore will generate warnings when encountered -- and many packages that use OpenEXR's public headers use -Werr to turn warnings into errors. Starting in C++17, the keyword is removed entirely, and thus will certainly be a build break for that version of the standard. So it's time for it to go.