### PR TITLE
fix defect in semaphore implementation which caused application hang …

### DIFF
--- a/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
@@ -126,7 +126,16 @@ Semaphore::post ()
 
     if (_semaphore.numWaiting > 0)
     {
-        if (int error = ::pthread_cond_signal (&_semaphore.nonZero))
+        int error;
+        if (_semaphore.numWaiting > 1 && _semaphore.count > 1)
+        {
+            error =  ::pthread_cond_broadcast (&_semaphore.nonZero);
+        }
+        else
+        {
+            error = ::pthread_cond_signal (&_semaphore.nonZero);
+        }
+        if (error)
         {
             ::pthread_mutex_unlock (&_semaphore.mutex);
 


### PR DESCRIPTION
…at exit time, because not all worker threads get woken up when task semaphore is repeatedly posted (to wake them all up) after setting the stopping flag in the thread pool.  This defect was observed on a 2013 mac pro, with OSX 10.11 and XCode 7.1.  I initially tried just replacing the pthread_cond_signal() call with pthread_cond_broadcast(), but this created a huge performance regression in our application (decoding 4k EXR files).  Using the broadcast call only when necessary seems to maintain an acceptable performance level, but I did not run benchmarks to quantify the difference.