### PR TITLE
Fixes the not-increasing memory leak in openExr.

### DIFF
--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -105,7 +105,12 @@ class IMF_EXPORT Attribute
     //-----------------------------------------------------------
 
     static bool			knownType (const char typeName[]);
-
+ 
+    //------------------------------------------------------
+    // Un-register all known attributes.
+    //------------------------------------------------------
+ 
+    static void clearAttributeRegistration();
 
   protected:
 

--- a/OpenEXR/IlmImf/ImfHeader.cpp
+++ b/OpenEXR/IlmImf/ImfHeader.cpp
@@ -1228,14 +1228,16 @@ Header::readFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int &version)
     }
 }
 
+static bool initialized = false;
+static Mutex criticalSection;
 
 void
 staticInitialize ()
 {
-    static Mutex criticalSection;
+    //static Mutex criticalSection;
     Lock lock (criticalSection);
 
-    static bool initialized = false;
+    //static bool initialized = false;
 
     if (!initialized)
     {
@@ -1278,6 +1280,17 @@ staticInitialize ()
 	initialized = true;
     }
 }
+
+void
+staticUninitialize ()
+{
+    Lock lock (criticalSection);
+
+    Attribute::clearAttributeRegistration();
+
+    initialized = false;
+}
+
 
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/OpenEXR/IlmImf/ImfHeader.h
+++ b/OpenEXR/IlmImf/ImfHeader.h
@@ -493,8 +493,8 @@ class Header::ConstIterator
 //
 //------------------------------------------------------------------------
 
-void staticInitialize ();
-
+IMF_EXPORT void staticInitialize ();
+IMF_EXPORT void staticUninitialize();
 
 //-----------------
 // Inline Functions


### PR DESCRIPTION
Developers have to call staticUninitialize(); at the end of their application.