### PR TITLE
Improve read performance for deep/zipped data

### DIFF
--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -147,14 +147,18 @@ bytesPerDeepLineTable (const Header &header,
          c != channels.end();
          ++c)
     {
+        const int ySampling = c.channel().ySampling;
+        const int xSampling = c.channel().xSampling;
+        const int pixelSize = pixelTypeSize (c.channel().type);
+
         for (int y = minY; y <= maxY; ++y)
-            if (modp (y, c.channel().ySampling) == 0)
+            if (modp (y, ySampling) == 0)
             {
                 int nBytes = 0;
                 for (int x = dataWindow.min.x; x <= dataWindow.max.x; x++)
                 {
-                    if (modp (x, c.channel().xSampling) == 0)
-                        nBytes += pixelTypeSize (c.channel().type) *
+                    if (modp (x, xSampling) == 0)
+                        nBytes += pixelSize *
                                   sampleCount(base, xStride, yStride, x, y);
                 }
                 bytesPerLine[y - dataWindow.min.y] += nBytes;

--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -132,6 +132,18 @@ bytesPerLineTable (const Header &header,
     return maxBytesPerLine;
 }
 
+static int
+roundToNextMultiple(int n, int d)
+{
+    return ((n + d - 1) / d) * d;
+}
+
+static int
+roundToPrevMultiple(int n, int d)
+{
+    return (n / d) * d;
+}
+
 size_t
 bytesPerDeepLineTable (const Header &header,
                        int minY, int maxY,
@@ -147,22 +159,33 @@ bytesPerDeepLineTable (const Header &header,
          c != channels.end();
          ++c)
     {
-        const int ySampling = c.channel().ySampling;
-        const int xSampling = c.channel().xSampling;
+        const int ySampling = abs(c.channel().ySampling);
+        const int xSampling = abs(c.channel().xSampling);
         const int pixelSize = pixelTypeSize (c.channel().type);
 
-        for (int y = minY; y <= maxY; ++y)
-            if (modp (y, ySampling) == 0)
+        // Here we transform from the domain over all pixels into the domain
+        // of actual samples.  We want to sample points in [minY, maxY] where
+        // (y % ySampling) == 0.  However, doing this by rejecting samples
+        // requires O(height*width) modulo computations, which were a
+        // significant bottleneck in the previous implementation of this
+        // function.  For the low, low price of 4 divisions per channel, we
+        // can tighten the y & x ranges to the least and greatest roots of the
+        // sampling function and then stride by the sampling rate.
+        const int sampleMinY = roundToNextMultiple(minY, ySampling);
+        const int sampleMaxY = roundToPrevMultiple(maxY, ySampling);
+        const int sampleMinX = roundToNextMultiple(dataWindow.min.x, xSampling);
+        const int sampleMaxX = roundToPrevMultiple(dataWindow.max.x, xSampling);
+
+        for (int y = sampleMinY; y <= sampleMaxY; y+=ySampling)
+        {
+            int nBytes = 0;
+            for (int x = sampleMinX; x <= sampleMaxX; x += xSampling)
             {
-                int nBytes = 0;
-                for (int x = dataWindow.min.x; x <= dataWindow.max.x; x++)
-                {
-                    if (modp (x, xSampling) == 0)
-                        nBytes += pixelSize *
-                                  sampleCount(base, xStride, yStride, x, y);
-                }
-                bytesPerLine[y - dataWindow.min.y] += nBytes;
+                nBytes += pixelSize *
+                          sampleCount(base, xStride, yStride, x, y);
             }
+            bytesPerLine[y - dataWindow.min.y] += nBytes;
+        }
     }
 
     size_t maxBytesPerLine = 0;

--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -132,26 +132,6 @@ bytesPerLineTable (const Header &header,
     return maxBytesPerLine;
 }
 
-
-const int&
-sampleCount(const char* base, int xStride, int yStride, int x, int y)
-{
-    const char* ptr = base + y * yStride + x * xStride;
-    int* intPtr = (int*) ptr;
-
-    return *intPtr;
-}
-
-int&
-sampleCount(char* base, int xStride, int yStride, int x, int y)
-{
-    char* ptr = base + y * yStride + x * xStride;
-    int* intPtr = (int*) ptr;
-    
-    return *intPtr;
-}
-
-
 size_t
 bytesPerDeepLineTable (const Header &header,
                        int minY, int maxY,

--- a/OpenEXR/IlmImf/ImfMisc.h
+++ b/OpenEXR/IlmImf/ImfMisc.h
@@ -95,14 +95,26 @@ size_t	bytesPerLineTable (const Header &header,
 // pointer, xStride and yStride.
 //
 
-IMF_EXPORT
+inline
 int&
-sampleCount(char* base, int xStride, int yStride, int x, int y);
+sampleCount(char* base, int xStride, int yStride, int x, int y)
+{
+    char* ptr = base + y * yStride + x * xStride;
+    int* intPtr = (int*) ptr;
+
+    return *intPtr;
+}
 
 
-IMF_EXPORT
+inline
 const int&
-sampleCount(const char* base, int xStride, int yStride, int x, int y);
+sampleCount(const char* base, int xStride, int yStride, int x, int y)
+{
+    const char* ptr = base + y * yStride + x * xStride;
+    int* intPtr = (int*) ptr;
+    
+    return *intPtr;
+}
 
 //
 // Build a table that lists, for each scanline in a DEEP file's

--- a/OpenEXR/IlmImf/ImfSimd.h
+++ b/OpenEXR/IlmImf/ImfSimd.h
@@ -40,6 +40,7 @@
 //
 // Compile time SSE detection:
 //    IMF_HAVE_SSE2 - Defined if it's safe to compile SSE2 optimizations
+//    IMF_HAVE_SSE4_1 - Defined if it's safe to compile SSE4.1 optimizations
 //
 
 
@@ -48,11 +49,19 @@
     #define IMF_HAVE_SSE2 1
 #endif
 
+#if defined __SSE4_1__
+    #define IMF_HAVE_SSE4_1 1
+#endif
+
 extern "C"
 {
 #ifdef IMF_HAVE_SSE2
     #include <emmintrin.h>
     #include <mmintrin.h>
+#endif
+
+#ifdef IMF_HAVE_SSE4_1
+    #include <smmintrin.h>
 #endif
 }
 

--- a/OpenEXR/IlmImf/ImfZip.cpp
+++ b/OpenEXR/IlmImf/ImfZip.cpp
@@ -35,6 +35,7 @@
 #include "ImfZip.h"
 #include "ImfCheckedArithmetic.h"
 #include "ImfNamespace.h"
+#include "ImfSimd.h"
 #include "Iex.h"
 
 #include <math.h>
@@ -135,6 +136,130 @@ Imf::Zip::compress(const char *raw, int rawSize, char *compressed)
     return outSize;
 }
 
+#ifdef IMF_HAVE_SSE4_1
+
+static void
+reconstruct_sse41(char *buf, size_t outSize)
+{
+    static const size_t bytesPerChunk = sizeof(__m128i);
+    const size_t vOutSize = outSize / bytesPerChunk;
+
+    const __m128i c = _mm_set1_epi8(-128);
+    const __m128i shuffleMask = _mm_set1_epi8(15);
+
+    // The first element doesn't have its high bit flipped during compression,
+    // so it must not be flipped here.  To make the SIMD loop nice and
+    // uniform, we pre-flip the bit so that the loop will unflip it again.
+    buf[0] += -128;
+
+    __m128i *vBuf = reinterpret_cast<__m128i *>(buf);
+    __m128i vPrev = _mm_setzero_si128();
+    for (size_t i=0; i<vOutSize; ++i)
+    {
+        __m128i d = _mm_add_epi8(_mm_loadu_si128(vBuf), c);
+
+        // Compute the prefix sum of elements.
+        d = _mm_add_epi8(d, _mm_slli_si128(d, 1));
+        d = _mm_add_epi8(d, _mm_slli_si128(d, 2));
+        d = _mm_add_epi8(d, _mm_slli_si128(d, 4));
+        d = _mm_add_epi8(d, _mm_slli_si128(d, 8));
+        d = _mm_add_epi8(d, vPrev);
+
+        _mm_storeu_si128(vBuf++, d);
+
+        // Broadcast the high byte in our result to all lanes of the prev
+        // value for the next iteration.
+        vPrev = _mm_shuffle_epi8(d, shuffleMask);
+    }
+
+    unsigned char prev = _mm_extract_epi8(vPrev, 15);
+    for (size_t i=vOutSize*bytesPerChunk; i<outSize; ++i)
+    {
+        unsigned char d = prev + buf[i] - 128;
+        buf[i] = d;
+        prev = d;
+    }
+}
+
+#else
+
+static void
+reconstruct_scalar(char *buf, size_t outSize)
+{
+    unsigned char *t    = (unsigned char *) buf + 1;
+    unsigned char *stop = (unsigned char *) buf + outSize;
+
+    while (t < stop)
+    {
+        int d = int (t[-1]) + int (t[0]) - 128;
+        t[0] = d;
+        ++t;
+    }
+}
+
+#endif
+
+
+#ifdef IMF_HAVE_SSE2
+
+static void
+interleave_sse2(const char *source, size_t outSize, char *out)
+{
+    static const size_t bytesPerChunk = 2*sizeof(__m128i);
+
+    const size_t vOutSize = outSize / bytesPerChunk;
+
+    const __m128i *v1 = reinterpret_cast<const __m128i *>(source);
+    const __m128i *v2 = reinterpret_cast<const __m128i *>(source + (outSize + 1) / 2);
+    __m128i *vOut = reinterpret_cast<__m128i *>(out);
+
+    for (size_t i=0; i<vOutSize; ++i) {
+        __m128i a = _mm_loadu_si128(v1++);
+        __m128i b = _mm_loadu_si128(v2++);
+
+        __m128i lo = _mm_unpacklo_epi8(a, b);
+        __m128i hi = _mm_unpackhi_epi8(a, b);
+
+        _mm_storeu_si128(vOut++, lo);
+        _mm_storeu_si128(vOut++, hi);
+    }
+
+    const char *t1 = reinterpret_cast<const char *>(v1);
+    const char *t2 = reinterpret_cast<const char *>(v2);
+    char *sOut = reinterpret_cast<char *>(vOut);
+
+    for (size_t i=vOutSize*bytesPerChunk; i<outSize; ++i)
+    {
+        *(sOut++) = (i%2==0) ? *(t1++) : *(t2++);
+    }
+}
+
+#else
+
+static void
+interleave_scalar(const char *source, size_t outSize, char *out)
+{
+    const char *t1 = source;
+    const char *t2 = source + (outSize + 1) / 2;
+    char *s = out;
+    char *const stop = s + outSize;
+
+    while (true)
+    {
+        if (s < stop)
+            *(s++) = *(t1++);
+        else
+            break;
+
+        if (s < stop)
+            *(s++) = *(t2++);
+        else
+            break;
+    }
+}
+
+#endif
+
 int
 Imf::Zip::uncompress(const char *compressed, int compressedSize,
                                             char *raw)
@@ -151,44 +276,28 @@ Imf::Zip::uncompress(const char *compressed, int compressedSize,
         throw Iex::InputExc ("Data decompression (zlib) failed.");
     }
 
+    if (outSize == 0)
+    {
+        return outSize;
+    }
+
     //
     // Predictor.
     //
-    {
-        unsigned char *t    = (unsigned char *) _tmpBuffer + 1;
-        unsigned char *stop = (unsigned char *) _tmpBuffer + outSize;
-
-        while (t < stop)
-        {
-            int d = int (t[-1]) + int (t[0]) - 128;
-            t[0] = d;
-            ++t;
-        }
-    }
+#ifdef IMF_HAVE_SSE4_1
+    reconstruct_sse41(_tmpBuffer, outSize);
+#else
+    reconstruct_scalar(_tmpBuffer, outSize);
+#endif
 
     //
     // Reorder the pixel data.
     //
-
-    {
-        const char *t1 = _tmpBuffer;
-        const char *t2 = _tmpBuffer + (outSize + 1) / 2;
-        char *s = raw;
-        char *stop = s + outSize;
-
-        while (true)
-        {
-            if (s < stop)
-            *(s++) = *(t1++);
-            else
-            break;
-
-            if (s < stop)
-            *(s++) = *(t2++);
-            else
-            break;
-        }
-    }
+#ifdef IMF_HAVE_SSE2
+    interleave_sse2(_tmpBuffer, outSize, raw);
+#else
+    interleave_scalar(_tmpBuffer, outSize, raw);
+#endif
 
     return outSize;
 }


### PR DESCRIPTION
This series of patches improves load time for deep exrs that use zip compression by roughly 45% (as profiled on Haswell & Skylake machines with gcc 4.8.)  I've tried to ensure that none of these changes will impair compilers that make different optimization choices, but I'd love to get feedback from folks on different toolchains and architectures.  clang users may see smaller speedups as I believe it will happily inline functions with default ELF visibility.

Note: commit c7e1eba is ABI-incompatible with OpenEXR 2.2 but all changes should be API compatible.