### PR TITLE
OpenEXR: Fix autotools build system and change doc install

### DIFF
--- a/OpenEXR/IlmImf/Makefile.am
+++ b/OpenEXR/IlmImf/Makefile.am
@@ -93,7 +93,7 @@ libIlmImf_la_SOURCES = ImfForward.h ImfAttribute.cpp ImfBoxAttribute.cpp ImfCRgb
 	               ImfSystemSpecific.cpp ImfZip.h ImfZip.cpp
 
 
-libIlmImf_la_LDFLAGS = @ILMBASE_LDFLAGS@ -version-info @LIBTOOL_VERSION@ \
+libIlmImf_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ \
 			-no-undefined 
 
 
@@ -102,7 +102,7 @@ libIlmImf_la_LDFLAGS += -release @LIB_SUFFIX@
 endif
 
 
-libIlmImf_la_LIBADD =  -lz @ILMBASE_LIBS@
+libIlmImf_la_LIBADD = $(ZLIB_LIBS) $(ILMBASE_LIBS)
 
 libIlmImfincludedir = $(includedir)/OpenEXR
 
@@ -189,20 +189,21 @@ noinst_HEADERS = ImfCompressor.h    \
 EXTRA_DIST = $(noinst_HEADERS) b44ExpLogTable.cpp b44ExpLogTable.h dwaLookups.cpp dwaLookups.h CMakeLists.txt
 
 
-INCLUDES = @ILMBASE_CXXFLAGS@ \
-	   -I$(top_builddir)  \
-	   -I$(top_srcdir)/config
+INCLUDES = \
+	   -I$(top_builddir) \
+	   -I$(top_srcdir)/config \
+	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 CLEANFILES = b44ExpLogTable b44ExpLogTable.h dwaLookups dwaLookups.h
 
 b44ExpLogTable_SOURCES = b44ExpLogTable.cpp
-b44ExpLogTable_LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@
+b44ExpLogTable_LDADD = $(ILMBASE_LIBS)
 
 b44ExpLogTable.h: b44ExpLogTable
 	./b44ExpLogTable > b44ExpLogTable.h
 
 dwaLookups_SOURCES = dwaLookups.cpp
-dwaLookups_LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@
+dwaLookups_LDADD = $(ILMBASE_LIBS)
 
 dwaLookups.h: dwaLookups
 	./dwaLookups > dwaLookups.h

--- a/OpenEXR/IlmImfExamples/Makefile.am
+++ b/OpenEXR/IlmImfExamples/Makefile.am
@@ -6,11 +6,11 @@ endif
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	@ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
-	-lIlmImf -lz
+	$(ILMBASE_LIBS) \
+	-lIlmImf $(ZLIB_CFLAGS)
 
 imfexamples_SOURCES = main.cpp drawImage.cpp rgbaInterfaceExamples.cpp \
 		      rgbaInterfaceTiledExamples.cpp \
@@ -23,7 +23,7 @@ imfexamples_SOURCES = main.cpp drawImage.cpp rgbaInterfaceExamples.cpp \
 		      lowLevelIoExamples.h previewImageExamples.h \
 		      namespaceAlias.h
 
-examplesdir = $(datadir)/doc/OpenEXR-@OPENEXR_VERSION@/examples
+examplesdir = $(docdir)/examples
 examples_DATA = $(imfexamples_SOURCES)
 
 imfexamplesdir = $(examplesdir)

--- a/OpenEXR/IlmImfFuzzTest/Makefile.am
+++ b/OpenEXR/IlmImfFuzzTest/Makefile.am
@@ -14,11 +14,11 @@ IlmImfFuzzTest_SOURCES = fuzzFile.cpp fuzzFile.h main.cpp tmpDir.h \
 INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	@ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
-	-lIlmImf -lz
+	$(ILMBASE_LIBS) \
+	-lIlmImf $(ZLIB_LIBS)
 
 if BUILD_IMFFUZZTEST
 TESTS = IlmImfFuzzTest

--- a/OpenEXR/IlmImfTest/Makefile.am
+++ b/OpenEXR/IlmImfTest/Makefile.am
@@ -64,11 +64,11 @@ endif
 INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	@ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
-	-lIlmImf -lz
+	$(ILMBASE_LIBS) \
+	-lIlmImf $(ZLIB_LIBS)
 
 TESTS = IlmImfTest
 

--- a/OpenEXR/IlmImfUtil/Makefile.am
+++ b/OpenEXR/IlmImfUtil/Makefile.am
@@ -20,7 +20,7 @@ libIlmImfUtil_la_SOURCES = \
 	ImfImageChannelRenaming.h
 	
 
-libIlmImfUtil_la_LDFLAGS = @ILMBASE_LDFLAGS@ -version-info @LIBTOOL_VERSION@ \
+libIlmImfUtil_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ \
 			-no-undefined 
 
 
@@ -29,14 +29,15 @@ libIlmImfUtil_la_LDFLAGS += -release @LIB_SUFFIX@
 endif
 
 
-libIlmImfUtil_la_LIBADD =  -L$(top_builddir)/IlmImf @ILMBASE_LIBS@ -lIlmImf
+libIlmImfUtil_la_LIBADD =  -L$(top_builddir)/IlmImf $(ILMBASE_LIBS) -lIlmImf
 
 libIlmImfUtilincludedir = $(includedir)/OpenEXR
 
 EXTRA_DIST = CMakeLists.txt
 
-INCLUDES = @ILMBASE_CXXFLAGS@ \
-	   -I$(top_builddir)  \
-	   -I$(top_srcdir)/IlmImf  \
-	   -I$(top_srcdir)/config
+INCLUDES = \
+	   -I$(top_builddir) \
+	   -I$(top_srcdir)/IlmImf \
+	   -I$(top_srcdir)/config \
+	   $(ILMBASE_CFLAGS)
 

--- a/OpenEXR/IlmImfUtilTest/Makefile.am
+++ b/OpenEXR/IlmImfUtilTest/Makefile.am
@@ -11,12 +11,12 @@ INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/IlmImfUtil \
 	   -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
 	-L$(top_builddir)/IlmImfUtil \
-	@ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
-	-lIlmImfUtil -lIlmImf -lz
+	$(ILMBASE_LIBS) \
+	-lIlmImfUtil -lIlmImf $(ZLIB_LIBS)
 
 TESTS = IlmImfUtilTest
 

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -1,6 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT(OpenEXR, 2.2.0)
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_SUBST(OPENEXR_VERSION_MAJOR, 2)
 AC_SUBST(OPENEXR_VERSION_MINOR, 2)
@@ -11,9 +12,8 @@ AC_SUBST(OPENEXR_VERSION_API, ${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR})
 
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(IlmImfTest/main.cpp)
-AC_CONFIG_HEADER(config/OpenEXRConfig.h)
-AM_INIT_AUTOMAKE(1.6.3)  dnl Require automake 1.6.3 or better
-AM_MAINTAINER_MODE
+AC_CONFIG_HEADERS([config/OpenEXRConfig.h])
+AM_INIT_AUTOMAKE
 
 
 LIBTOOL_CURRENT=22
@@ -27,46 +27,21 @@ AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_CC
 AC_PROG_LN_S
-AC_PROG_LIBTOOL
+LT_INIT
 AC_PROG_MAKE_SET
 
 dnl
 dnl PKGCONFIG preparations
 dnl
-
-if test -z "${PKG_CONFIG_PATH}"; then
-	PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/pkgconfig
-fi
-
-LIB64_IF_EXISTS=""
-if [[ -e /usr/lib64 ]]; then
-   LIB64_IF_EXISTS="-L/usr/lib64"
-fi         
-
-
-
-export PKG_CONFIG_PATH
-
-dnl
-dnl get ccflags and libs from openexr packages, then check 
-dnl whether test programs compile
-AM_PATH_PKGCONFIG(
-   [ILMBASE_CXXFLAGS],
-   [ILMBASE_LDFLAGS],
-   [ILMBASE_LIBS],
-   [IlmBase],
-   [OpenEXR],
-   [$LIB64_IF_EXISTS -L/usr/local/lib],
-   [-lImath -lHalf -lIex -lIlmThread -lpthread],
-   [ilmbase-prefix])
+PKG_CHECK_MODULES([ILMBASE], [IlmBase])
 
 
 dnl Define the version string
-AC_DEFINE_UNQUOTED(OPENEXR_VERSION_STRING, "${VERSION}")
-AC_DEFINE_UNQUOTED(OPENEXR_PACKAGE_STRING, "${PACKAGE_STRING}")
-AC_DEFINE_UNQUOTED(OPENEXR_VERSION_MAJOR, ${OPENEXR_VERSION_MAJOR})
-AC_DEFINE_UNQUOTED(OPENEXR_VERSION_MINOR, ${OPENEXR_VERSION_MINOR})
-AC_DEFINE_UNQUOTED(OPENEXR_VERSION_PATCH, ${OPENEXR_VERSION_PATCH})
+AC_DEFINE_UNQUOTED([OPENEXR_VERSION_STRING], [${VERSION}], [OpenEXR version string])
+AC_DEFINE_UNQUOTED([OPENEXR_PACKAGE_STRING], [${PACKAGE_STRING}], [OpenEXR version string])
+AC_DEFINE_UNQUOTED([OPENEXR_VERSION_MAJOR], [${OPENEXR_VERSION_MAJOR}], [OpenEXR version string])
+AC_DEFINE_UNQUOTED([OPENEXR_VERSION_MINOR], [${OPENEXR_VERSION_MINOR}], [OpenEXR version string])
+AC_DEFINE_UNQUOTED([OPENEXR_VERSION_PATCH], [${OPENEXR_VERSION_PATCH}], [OpenEXR version string])
 
 
 dnl --enable-threading
@@ -75,19 +50,16 @@ AC_ARG_ENABLE(threading,
                              [enable multi-threading [[default=yes]]]),
               [multithread="${enableval}"], [multithread=yes])
 
-if test x$PKG_CONFIG == xno && test "x${multithread}" != xno ; then
-    ACX_PTHREAD(
-    [
-	AC_DEFINE(OPENEXR_IMF_HAVE_PTHREAD)
-	ILMBASE_LIBS="$PTHREAD_LIBS $ILMBASE_LIBS"
-	ILMBASE_CXXFLAGS="$ILMBASE_CXXFLAGS $PTHREAD_CFLAGS"
-	CC="$PTHREAD_CC"
-	
-	AM_POSIX_SEM()
-    ],
-    [AC_MSG_ERROR([POSIX thread support required])])
-    AC_MSG_NOTICE([multithread true, LIBS = $LIBS, CC = $CC, CXXFLAGS = $CXXFLAGS])
-fi
+AS_IF([test "x${multithread}" != xno], [
+	AX_PTHREAD
+
+	AC_DEFINE([OPENEXR_IMF_HAVE_PTHREAD], [1], [Define if pthreads are available])
+
+	CFLAGS="${CFLAGS} ${PTHREAD_CFLAGS}"
+	CXXFLAGS="${CXXFLAGS} ${PTHREAD_CFLAGS}"
+	LIBS="${LIBS} ${PTHREAD_CFLAGS}"
+])
+
 
 dnl --enable-large-stack
 case "$host" in
@@ -110,21 +82,25 @@ case "$host" in
 esac
 
 if test "x${large_stack}" != xno ; then
-    AC_DEFINE(OPENEXR_IMF_HAVE_LARGE_STACK)
+    AC_DEFINE([OPENEXR_IMF_HAVE_LARGE_STACK], [1], [Define if large stack sizes are supported])
 fi
 
-AM_COMPILELINKRUN(
-   [IlmBase],
-   [ilmbasetest],
-   [$ILMBASE_CXXFLAGS],
-   [$ILMBASE_LDFLAGS],
-   [$ILMBASE_LIBS],[[
-#include <stdlib.h>
-#include <ImathFun.h>
-]],
-   [[double d = IMATH_NAMESPACE::succd(.23); d+= .2;]],
-   AC_MSG_RESULT([Compiled and ran IlmBase test program.]), 
-   AC_MSG_ERROR([Could not compile IlmBase test program.]))
+
+
+save_CXXFLAGS="${CXXFLAGS}"
+save_LIBS="${LIBS}"
+CXXFLAGS="${save_CXXFLAGS} ${ILMBASE_CFLAGS}"
+LIBS="${save_LIBS} ${ILMBASE_LIBS}"
+AC_LINK_IFELSE([
+	AC_LANG_PROGRAM([[
+		#include <stdlib.h>
+		#include <ImathFun.h>
+	]], [[
+		double d = IMATH_NAMESPACE::succd(.23); d+= .2;
+	]])
+])
+CXXFLAGS="${save_CXXFLAGS}"
+LIBS="${save_LIBS}"
 
 
 dnl Checks for header files.
@@ -137,74 +113,27 @@ AC_C_INLINE
 AC_TYPE_SIZE_T
 
 dnl Checks for zlib
-AC_CHECK_LIB(z, compress,
-             [:],
-             [AC_MSG_ERROR([
-*** OpenEXR requires a recent version of zlib, which you don't appear to
-*** have.
-***
-*** This could be because the run-time linker is not finding zlib, or it
-*** is finding the wrong version.  In this case, you'll need to set your
-*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point
-*** to the proper version.  Also, make sure you have run ldconfig if
-*** that is required on your system.
-			   ])]
-)
-
-dnl Checks for std::right etc. in iomanip
-AC_MSG_CHECKING(for complete iomanip support in C++ standard library)
-complete_iomanip="no"
-AC_LANG_SAVE
-AC_LANG_CPLUSPLUS
-AC_TRY_COMPILE([#include <iomanip>],[
-
-	std::right;
-],
-AC_DEFINE(OPENEXR_IMF_HAVE_COMPLETE_IOMANIP) complete_iomanip=yes)
-AC_MSG_RESULT($complete_iomanip)
-AC_LANG_RESTORE
+PKG_CHECK_MODULES([ZLIB], [zlib])
 
 
-AC_MSG_CHECKING(for gcc optimization flags)
-old_cflags=$CFLAGS
-CFLAGS="$CFLAGS -pipe"
-AC_TRY_COMPILE([#include <stdio.h>],
-[ printf ("hello, world"); ],
-[ EXTRA_OPT_CFLAGS="-pipe"],[ EXTRA_OPT_CFLAGS=""])
-CFLAGS=$old_cflags
-AC_MSG_RESULT([$EXTRA_OPT_CFLAGS])
+dnl We use a modern toolchain, don't care
+dnl about ancient broken stuff
+AC_DEFINE([OPENEXR_IMF_HAVE_COMPLETE_IOMANIP], [1], [Define when std::right is available])
+
 
 dnl Check to see if the toolset supports AVX instructions in inline asm
-AC_MSG_CHECKING(for AVX instructions in GCC style inline asm)
-gcc_inline_asm_avx="no"
-AC_COMPILE_IFELSE(
-    [
-        AC_LANG_PROGRAM([],
-        [
-             #if defined(__GNUC__) && defined(__SSE2__) 
-                 int n   = 0;
-                 int eax = 0;
-                 int edx = 0;
-                 __asm__(
-                     "xgetbv     \n"
-                     "vzeroupper  "
-                     : "=a"(eax), "=d"(edx) : "c"(n));
-             #else
-                 #error No GCC style inline asm supported for AVX instructions
-             #endif
-        ]) 
-   ],
-   [
-      gcc_inline_asm_avx="yes"
-   ],
-   [
-      gcc_inline_asm_avx="no"
-   ]
-)
-AC_MSG_RESULT([$gcc_inline_asm_avx])
-if test "x${gcc_inline_asm_avx}" == xyes ; then
-    AC_DEFINE(OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX)
-fi
+AC_ARG_ENABLE([avx],
+	AS_HELP_STRING([--enable-avx], [Enable avx optimization]))
+
+AS_IF([test "x$enable_avx" = "xyes"], [
+	dnl Enable AVX
+	gcc_inline_asm_avx="yes"
+	AC_DEFINE([OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX], [1], [Define if AVX is available])
+], [
+	dnl Disable AVX
+	gcc_inline_asm_avx="no"
+])
+
 
 dnl Check if sysconf(_SC_NPROCESSORS_ONLN) can be used for CPU count
 AC_MSG_CHECKING([for sysconf(_SC_NPROCESSORS_ONLN)])
@@ -221,16 +150,16 @@ AC_COMPILE_IFELSE(
 )
 AC_MSG_RESULT([$sysconf_nproc])
 if test "x${sysconf_nproc}" == xyes ; then
-    AC_DEFINE(OPENEXR_IMF_HAVE_SYSCONF_NPROCESSORS_ONLN)
+    AC_DEFINE([OPENEXR_IMF_HAVE_SYSCONF_NPROCESSORS_ONLN], [1], [Define if sysconf(_SC_NPROCESSORS_ONLN) can be used for CPU count])
 fi
 
 dnl Platform-specific stuff
 case "$host" in
 *linux*)
-  AC_DEFINE(OPENEXR_IMF_HAVE_LINUX_PROCFS)
+  AC_DEFINE([OPENEXR_IMF_HAVE_LINUX_PROCFS], [1], [Define if procfs is available])
   ;;
 *darwin*) 
-  AC_DEFINE(OPENEXR_IMF_HAVE_DARWIN) 
+  AC_DEFINE([OPENEXR_IMF_HAVE_DARWIN], [1], [Define if on Darwin])
 
   dnl OS X universal binary support, requires --disable-dependency-tracking
   AC_ARG_ENABLE(osx-universal-binaries,
@@ -245,18 +174,12 @@ Please re-run configure with these options:
   --disable-dependency-tracking --enable-osx-universal-binary
   		  ])
     fi
-    CXXFLAGS="$CXXFLAGS -isysroot /Developer/SDKs/MacOSX10.4u.sdk -arch ppc -arch i386"
+    dnl CXXFLAGS="$CXXFLAGS -isysroot /Developer/SDKs/MacOSX10.4u.sdk -arch ppc -arch i386"
     dnl LDFLAGS="$LDFLAGS -Wl,-syslibroot,/Developer/SDKs/MacOSX10.4u.sdk -arch ppc -arch i386"
   fi
 
   ;;
 esac
-
-AM_CFLAGS="$EXTRA_OPT_CFLAGS"
-AM_CXXFLAGS="$EXTRA_OPT_CFLAGS"
-
-AC_SUBST(AM_CFLAGS)
-AC_SUBST(AM_CXXFLAGS)
 
 dnl build imfexamples example program?
 build_imfexamples="no"
@@ -286,7 +209,7 @@ AC_ARG_ENABLE(imfhugetest,
 AM_CONDITIONAL(BUILD_IMFHUGETEST, test "x$build_imfhugetest" = xyes)
 
 if test "x${build_imfhugetest}" != xno ; then
-    AC_DEFINE(OPENEXR_IMF_HUGETEST)
+    AC_DEFINE([OPENEXR_IMF_HUGETEST], [1], [Define if IlmImf huge input resilience])
 fi
 
 
@@ -307,19 +230,19 @@ lib_suffix_valid="no"
 
 lib_namespace="Imf"
 if test "x${library_namespace_versioning}" == xyes ; then
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_INTERNAL_NAMESPACE, Imf_${OPENEXR_VERSION_API})
-    AC_DEFINE(OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_INTERNAL_NAMESPACE], [Imf_${OPENEXR_VERSION_API}], [OpenEXR])
+    AC_DEFINE([OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM], [1], [OpenEXR])
 
     lib_namespace="Imf_${OPENEXR_VERSION_API}"
     LIB_SUFFIX="${OPENEXR_VERSION_API}"
     lib_suffix_valid="yes"
 elif test "x${library_namespace_versioning}" == xno ; then
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_INTERNAL_NAMESPACE, Imf)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_INTERNAL_NAMESPACE], [Imf], [OpenEXR])
 
     lib_namespace="Imf"
 else
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_INTERNAL_NAMESPACE, ${library_namespace_versioning} )
-    AC_DEFINE(OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_INTERNAL_NAMESPACE], [${library_namespace_versioning}], [OpenEXR])
+    AC_DEFINE([OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM], [1], [OpenEXR])
 
     lib_namespace="${library_namespace_versioning}"
     LIB_SUFFIX="${library_namespace_versioning}"
@@ -349,14 +272,14 @@ AC_ARG_ENABLE(customusernamespace,
 
 if test "x${custom_usr_namespace}" == xyes ; then
     AC_MSG_WARN([Enabling 'custom user namespace' requires an additional argument, reverting to 'Imf'])
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_NAMESPACE, Imf)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_NAMESPACE], [Imf], [OpenEXR])
     usr_namespace="Imf"
 elif test "x${custom_usr_namespace}" == xno ; then
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_NAMESPACE, Imf)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_NAMESPACE], [Imf], [OpenEXR])
     usr_namespace="Imf"
 else
-    AC_DEFINE_UNQUOTED(OPENEXR_IMF_NAMESPACE, ${custom_usr_namespace})
-    AC_DEFINE(OPENEXR_IMF_NAMESPACE_CUSTOM)
+    AC_DEFINE_UNQUOTED([OPENEXR_IMF_NAMESPACE], [${custom_usr_namespace}], [OpenEXR])
+    AC_DEFINE([OPENEXR_IMF_NAMESPACE_CUSTOM], [1], [OpenEXR])
     
     usr_namespace=${custom_usr_namespace}
 fi

--- a/OpenEXR/doc/Makefile.am
+++ b/OpenEXR/doc/Makefile.am
@@ -6,5 +6,4 @@ EXTRA_DIST =  \
 	InterpretingDeepPixels.pdf \
 	TheoryDeepPixels.pdf
 
-docdir=$(datadir)/doc/OpenEXR-@OPENEXR_VERSION@
 doc_DATA = $(EXTRA_DIST)

--- a/OpenEXR/exrenvmap/Makefile.am
+++ b/OpenEXR/exrenvmap/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrenvmap
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@\
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrenvmap_SOURCES = main.cpp EnvmapImage.cpp EnvmapImage.h \
 		    readInputImage.cpp readInputImage.h \

--- a/OpenEXR/exrheader/Makefile.am
+++ b/OpenEXR/exrheader/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrheader
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrheader_SOURCES = main.cpp
 

--- a/OpenEXR/exrmakepreview/Makefile.am
+++ b/OpenEXR/exrmakepreview/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrmakepreview
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@\
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrmakepreview_SOURCES = main.cpp makePreview.cpp makePreview.h
 

--- a/OpenEXR/exrmaketiled/Makefile.am
+++ b/OpenEXR/exrmaketiled/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrmaketiled
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrmaketiled_SOURCES = main.cpp \
 		       Image.h Image.cpp \

--- a/OpenEXR/exrmultipart/Makefile.am
+++ b/OpenEXR/exrmultipart/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrmultipart
 
 INCLUDES = -I$(top_builddir) \
 -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-@ILMBASE_CXXFLAGS@
+$(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
-$(top_builddir)/IlmImf/libIlmImf.la \
--lz
+LDADD = $(ILMBASE_LIBS) \
+	$(top_builddir)/IlmImf/libIlmImf.la \
+	$(ZLIB_LIBS)
 
 exrmultipart_SOURCES = exrmultipart.cpp
 

--- a/OpenEXR/exrmultiview/Makefile.am
+++ b/OpenEXR/exrmultiview/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrmultiview
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrmultiview_SOURCES = main.cpp  \
 		       Image.h Image.cpp \

--- a/OpenEXR/exrstdattr/Makefile.am
+++ b/OpenEXR/exrstdattr/Makefile.am
@@ -4,11 +4,11 @@ bin_PROGRAMS = exrstdattr
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-	   @ILMBASE_CXXFLAGS@
+           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = @ILMBASE_LDFLAGS@ @ILMBASE_LIBS@ \
+LDADD = $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
-	-lz
+	$(ZLIB_LIBS)
 
 exrstdattr_SOURCES = main.cpp CMakeLists.txt
 

--- a/OpenEXR/m4/path.pkgconfig.m4
+++ b/OpenEXR/m4/path.pkgconfig.m4
@@ -50,8 +50,7 @@ TEST_LIBS=""
 AC_ARG_WITH(arg_test_prefix,[  --with-arg_test_prefix=PFX  Prefix where tested libraries are supposed to be installed (optional)], test_prefix="$withval", test_prefix="NONE")
 echo "test_prefix = $test_prefix"
 
-AC_ARG_VAR(PKG_CONFIG, Path to pkg-config command)
-AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+PKG_PROG_PKG_CONFIG
 AC_ARG_WITH(pkg-config,[  --with-pkg-config=PATH Specify which pkg-config to use (optional)], PKG_CONFIG="$withval",)
 
 


### PR DESCRIPTION
The build sysem for the OpenEXR sub-module is greatly broken.
This patch is being used on Gentoo Linux with great success.
It also adresses the issue of linking to previously installed
versions.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)
Signed-off by: David Seifert (soap@gentoo.org)