### PR TITLE
Missing symbols on Windows due to missing IMF_EXPORT

### DIFF
--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -132,7 +132,7 @@ class IMF_EXPORT Attribute
 //-------------------------------------------------
     
 template <class T>
-class TypedAttribute: public Attribute
+class IMF_EXPORT TypedAttribute: public Attribute
 {
   public:
 

--- a/OpenEXR/IlmImf/ImfHeader.h
+++ b/OpenEXR/IlmImf/ImfHeader.h
@@ -493,7 +493,7 @@ class Header::ConstIterator
 //
 //------------------------------------------------------------------------
 
-void staticInitialize ();
+void IMF_EXPORT staticInitialize ();
 
 
 //-----------------


### PR DESCRIPTION
Added IMF_EXPORT to some classes in order to help the OpenEXR python binding compile.