### PR TITLE
Ilmbase enable cxx14, thread pool improvements

### DIFF
--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -35,8 +35,8 @@ OPTION (FORCE_CXX03 "Force CXX03" OFF)
 IF (FORCE_CXX03)
   ADD_DEFINITIONS ( -std=c++03 )
 ELSE (FORCE_CXX03)
-  # VP18 switches to c++14, so let's do that
-  SET(CMAKE_CXX_STANDARD 14)
+  # VP18 switches to c++14, so let's do that by default
+  SET(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
   # but switch gnu++14 or other extensions off for portability
   SET(CMAKE_CXX_EXTENSIONS OFF)
 ENDIF ()

--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -136,11 +136,11 @@ ELSE ()
 ENDIF ()
 
 IF (FORCE_CXX03)
-  FILE ( WRITE  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define ILMBASE_FORCE_CXX03 1\n" )
+  FILE ( APPEND  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define ILMBASE_FORCE_CXX03 1\n" )
 ELSE ()
   # really only care about c++11 right now for the threading bits, but this can be changed to 14
   # when needed...
-  FILE ( WRITE  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#if __cplusplus < 201103L\n# error \"Modern C++ 11/14 not enabled but force cxx98 not set\"\n#endif\n" )
+  FILE ( APPEND  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#if __cplusplus < 201103L\n# error \"Modern C++ 11/14 not enabled but force cxx03 not set\"\n#endif\n" )
 ENDIF ()
 
 IF (NAMESPACE_VERSIONING)

--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -31,6 +31,16 @@ OPTION (BUILD_SHARED_LIBS "Build Shared Libraries" ON)
 # Allow the developer to select if Dynamic or Static libraries are built
 OPTION (NAMESPACE_VERSIONING "Namespace Versioning" ON)
 
+OPTION (FORCE_CXX03 "Force CXX03" OFF)
+IF (FORCE_CXX03)
+  ADD_DEFINITIONS ( -std=c++03 )
+ELSE (FORCE_CXX03)
+  # VP18 switches to c++14, so let's do that
+  SET(CMAKE_CXX_STANDARD 14)
+  # but switch gnu++14 or other extensions off for portability
+  SET(CMAKE_CXX_EXTENSIONS OFF)
+ENDIF ()
+
 # Setup osx rpathing
 SET (CMAKE_MACOSX_RPATH 1)
 SET (BUILD_WITH_INSTALL_RPATH 1)
@@ -123,6 +133,14 @@ ELSE ()
     FILE ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define HAVE_POSIX_SEMAPHORES 1\n" )
     FILE ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define ILMBASE_HAVE_CONTROL_REGISTER_SUPPORT 1\n")
   ENDIF ()
+ENDIF ()
+
+IF (FORCE_CXX03)
+  FILE ( WRITE  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define ILMBASE_FORCE_CXX03 1\n" )
+ELSE ()
+  # really only care about c++11 right now for the threading bits, but this can be changed to 14
+  # when needed...
+  FILE ( WRITE  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#if __cplusplus < 201103L\n# error \"Modern C++ 11/14 not enabled but force cxx98 not set\"\n#endif\n" )
 ENDIF ()
 
 IF (NAMESPACE_VERSIONING)

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -62,11 +62,7 @@
 #ifdef ILMBASE_FORCE_CXX03
 #   define IEX_THROW_SPEC(...) throw (__VA_ARGS__)
 #else
-#   if __cplusplus <= 201402L
-#      define IEX_THROW_SPEC(...)
-#   else
-#      define IEX_THROW_SPEC(...) throw (__VA_ARGS__)
-#   endif
+#   define IEX_THROW_SPEC(...)
 #endif
 
 IEX_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -50,6 +50,25 @@
 #include <exception>
 #include <sstream>
 
+//----------------------------------------------------------
+//
+//	C++11 deprecates the specification of dynamic exception throw and
+//	then changes this again in C++17. for convenience, put a macro
+//	here to enable existing places to specify the exception list, and
+//	have it done so appropriately based on the language features
+//	active.
+//
+//----------------------------------------------------------
+#ifdef ILMBASE_FORCE_CXX03
+#   define IEX_THROW_SPEC(...) throw (__VA_ARGS__)
+#else
+#   if __cplusplus <= 201402L
+#      define IEX_THROW_SPEC(...)
+#   else
+#      define IEX_THROW_SPEC(...) throw (__VA_ARGS__)
+#   endif
+#endif
+
 IEX_INTERNAL_NAMESPACE_HEADER_ENTER
 
 

--- a/IlmBase/IlmThread/IlmThread.cpp
+++ b/IlmBase/IlmThread/IlmThread.cpp
@@ -34,21 +34,56 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class Thread -- dummy implementation for
-//	platforms that do not support threading
+//	class Thread -- this file contains two implementations of thread:
+//	- dummy implementation for platforms that do not support threading
+//	  when FORCE_CXX03 is on
+//	- c++11 and newer version
 //
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
-
-#if !defined (_WIN32) &&!(_WIN64) && !(HAVE_PTHREAD)
-
 #include "IlmThread.h"
 #include "Iex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
+#ifndef ILMBASE_FORCE_CXX03
+//-----------------------------------------------------------------------------
+// C++11 and newer implementation
+//-----------------------------------------------------------------------------
+bool
+supportsThreads ()
+{
+    return true;
+}
 
+Thread::Thread ()
+{
+    // empty
+}
+
+
+Thread::~Thread ()
+{
+    // hopefully the thread has basically exited and we are just
+    // cleaning up, because run is a virtual function, so the v-table
+    // has already been partly destroyed...
+    if ( _thread.joinable () )
+        _thread.join ();
+}
+
+
+void
+Thread::start ()
+{
+    _thread = std::thread (&Thread::run, this);
+}
+
+#else
+#   if !defined (_WIN32) &&!(_WIN64) && !(HAVE_PTHREAD)
+//-----------------------------------------------------------------------------
+// FORCE_CXX03 with no windows / pthread support
+//-----------------------------------------------------------------------------
 bool
 supportsThreads ()
 {
@@ -73,8 +108,9 @@ Thread::start ()
 {
     throw IEX_NAMESPACE::NoImplExc ("Threads not supported on this platform.");
 }
+#   endif
+#endif
 
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#endif

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -94,15 +94,19 @@
 #include "IlmThreadExport.h"
 #include "IlmThreadNamespace.h"
 
-#if defined _WIN32 || defined _WIN64
-    #ifdef NOMINMAX
-        #undef NOMINMAX
-    #endif
-    #define NOMINMAX
-    #include <windows.h>
-    #include <process.h>
-#elif HAVE_PTHREAD
-    #include <pthread.h>
+#ifdef ILMBASE_FORCE_CXX03
+#   if defined _WIN32 || defined _WIN64
+#       ifdef NOMINMAX
+#          undef NOMINMAX
+#       endif
+#       define NOMINMAX
+#       include <windows.h>
+#       include <process.h>
+#   elif HAVE_PTHREAD
+#      include <pthread.h>
+#   endif
+#else
+#   include <thread>
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -122,19 +126,25 @@ class ILMTHREAD_EXPORT Thread
     Thread ();
     virtual ~Thread ();
 
-    void		start ();
-    virtual void	run () = 0;
-    
+    void         start ();
+    virtual void run () = 0;
+
   private:
 
-    #if defined _WIN32 || defined _WIN64
+#ifdef ILMBASE_FORCE_CXX03
+#   if defined _WIN32 || defined _WIN64
 	HANDLE _thread;
-    #elif HAVE_PTHREAD
+#   elif HAVE_PTHREAD
 	pthread_t _thread;
-    #endif
-
+#   endif
     void operator = (const Thread& t);	// not implemented
     Thread (const Thread& t);		// not implemented
+#else
+    std::thread _thread;
+
+    Thread &operator= (const Thread& t) = delete;
+    Thread (const Thread& t) = delete;
+#endif
 };
 
 

--- a/IlmBase/IlmThread/IlmThreadForward.h
+++ b/IlmBase/IlmThread/IlmThreadForward.h
@@ -37,10 +37,18 @@
 
 #include "IlmThreadNamespace.h"
 
+#ifndef ILMBASE_FORCE_CXX03
+namespace std { class mutex; }
+#endif
+
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
 
 class Thread;
+#ifdef ILMBASE_FORCE_CXX03
 class Mutex;
+#else
+using Mutex = std::mutex;
+#endif
 class Lock;
 class ThreadPool;
 class Task;

--- a/IlmBase/IlmThread/IlmThreadMutex.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutex.cpp
@@ -41,9 +41,9 @@
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD)
-
-#include "IlmThreadMutex.h"
+#ifdef ILMBASE_FORCE_CXX03
+#   if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD)
+#      include "IlmThreadMutex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -56,4 +56,5 @@ void Mutex::unlock () const {}
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#   endif
 #endif

--- a/IlmBase/IlmThread/IlmThreadMutex.h
+++ b/IlmBase/IlmThread/IlmThreadMutex.h
@@ -70,20 +70,39 @@
 #include "IlmBaseConfig.h"
 #include "IlmThreadNamespace.h"
 
-#if defined _WIN32 || defined _WIN64
-    #ifdef NOMINMAX
-        #undef NOMINMAX
-    #endif
-    #define NOMINMAX
-    #include <windows.h>
-#elif HAVE_PTHREAD
-    #include <pthread.h>
+#ifdef ILMBASE_FORCE_CXX03
+#   if defined _WIN32 || defined _WIN64
+#      ifdef NOMINMAX
+#         undef NOMINMAX
+#      endif
+#      define NOMINMAX
+#      include <windows.h>
+#   elif HAVE_PTHREAD
+#      include <pthread.h>
+#   endif
+#else
+#   include <mutex>
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
 
-class Lock;
 
+// in c++11, this can just be
+//
+// using Mutex = std::mutex;
+// unfortunately we can't use std::unique_lock as a replacement for Lock since
+// they have different API.
+//
+// if we decide to break the API, we can just
+//
+// using Lock = std::lock_guard<std::mutex>;
+// or
+// using Lock = std::unique_lock<std::mutex>;
+//
+// (or eliminate the type completely and have people use the std library) 
+#ifdef ILMBASE_FORCE_CXX03
+
+class Lock;
 
 class ILMTHREAD_EXPORT Mutex
 {
@@ -108,15 +127,16 @@ class ILMTHREAD_EXPORT Mutex
     
     friend class Lock;
 };
-
+#else
+using Mutex = std::mutex;
+#endif
 
 class ILMTHREAD_EXPORT Lock
 {
   public:
 
-    Lock (const Mutex& m, bool autoLock = true):
-	_mutex (m),
-	_locked (false)
+    Lock (Mutex& m, bool autoLock = true):
+        _mutex (m), _locked (false)
     {
         if (autoLock)
         {
@@ -150,8 +170,8 @@ class ILMTHREAD_EXPORT Lock
 
   private:
 
-    const Mutex &	_mutex;
-    bool		_locked;
+    Mutex & _mutex;
+    bool    _locked;
 };
 
 

--- a/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
@@ -41,11 +41,12 @@
 
 #include "IlmBaseConfig.h"
 
-#if HAVE_PTHREAD
+#ifdef ILMBASE_FORCE_CXX03
+#   if HAVE_PTHREAD
 
-#include "IlmThreadMutex.h"
-#include "Iex.h"
-#include <assert.h>
+#      include "IlmThreadMutex.h"
+#      include "Iex.h"
+#      include <assert.h>
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -82,4 +83,5 @@ Mutex::unlock () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#   endif
 #endif

--- a/IlmBase/IlmThread/IlmThreadMutexWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexWin32.cpp
@@ -38,8 +38,11 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "IlmThreadMutex.h"
-#include "Iex.h"
+#include "IlmBaseConfig.h"
+
+#ifdef ILMBASE_FORCE_CXX03
+#   include "IlmThreadMutex.h"
+#   include "Iex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -71,3 +74,5 @@ Mutex::unlock () const
 
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
+
+#endif

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -34,7 +34,7 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class Task, class ThreadPool, class TaskGroup
+//  class Task, class ThreadPool, class TaskGroup
 //
 //-----------------------------------------------------------------------------
 
@@ -43,75 +43,173 @@
 #include "IlmThreadSemaphore.h"
 #include "IlmThreadPool.h"
 #include "Iex.h"
-#include <list>
+#include <vector>
+#ifndef ILMBASE_FORCE_CXX03
+# include <memory>
+# include <atomic>
+#endif
 
 using namespace std;
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
-namespace {
 
-class WorkerThread: public Thread
-{
-  public:
-
-    WorkerThread (ThreadPool::Data* data);
-
-    virtual void	run ();
-    
-  private:
-
-    ThreadPool::Data *	_data;
-};
-
-} //namespace
-
+#if defined(__GNU_LIBRARY__) && ( __GLIBC__ < 2 || ( __GLIBC__ == 2 && __GLIBC_MINOR__ < 21 ) )
+# define ENABLE_SEM_DTOR_WORKAROUND
+#endif
 
 struct TaskGroup::Data
 {
      Data ();
     ~Data ();
     
-    void	addTask () ;
-    void	removeTask ();
-    
-    Semaphore	isEmpty;        // used to signal that the taskgroup is empty
-    int         numPending;     // number of pending tasks to still execute
-    Mutex       dtorMutex;      // used to work around the glibc bug:
-                                // http://sources.redhat.com/bugzilla/show_bug.cgi?id=12674
+    void    addTask () ;
+    void    removeTask ();
+#ifndef ILMBASE_FORCE_CXX03
+    std::atomic<int> numPending;
+#else
+    int              numPending;     // number of pending tasks to still execute
+#endif
+    Semaphore        isEmpty;        // used to signal that the taskgroup is empty
+#if defined(ENABLE_SEM_DTOR_WORKAROUND) || defined(ILMBASE_FORCE_CXX03)
+    // this mutex is also used to lock numPending in the legacy c++ mode...
+    Mutex            dtorMutex;      // used to work around the glibc bug:
+                                     // http://sources.redhat.com/bugzilla/show_bug.cgi?id=12674
+#endif
 };
 
 
 struct ThreadPool::Data
 {
+#ifdef ILMBASE_FORCE_CXX03
+    typedef ThreadPoolProvider *TPPointer;
+#else
+    using TPPointer = std::shared_ptr<ThreadPoolProvider>;
+#endif
+
      Data ();
     ~Data();
-    
-    void	finish ();
-    bool	stopped () const;
-    void	stop ();
 
-    Semaphore taskSemaphore;        // threads wait on this for ready tasks
-    Mutex taskMutex;                // mutual exclusion for the tasks list
-    list<Task*> tasks;              // the list of tasks to execute
-    size_t numTasks;                // fast access to list size
-                                    //   (list::size() can be O(n))
+    struct SafeProvider
+    {
+        SafeProvider (Data *d, TPPointer p) : _data( d ), _ptr( p )
+        {}
 
-    Semaphore threadSemaphore;      // signaled when a thread starts executing
-    Mutex threadMutex;              // mutual exclusion for threads list
-    list<WorkerThread*> threads;    // the list of all threads
-    size_t numThreads;              // fast access to list size
-    
-    bool stopping;                  // flag indicating whether to stop threads
-    Mutex stopMutex;                // mutual exclusion for stopping flag
+        ~SafeProvider()
+        {
+            _data->coalesceProviderUse();
+        }
+        SafeProvider (const SafeProvider &o)
+            : _data( o._data ), _ptr( o._ptr )
+        {
+            _data->bumpProviderUse();
+        }
+        SafeProvider &operator= (const SafeProvider &o)
+        {
+            if ( this != &o )
+            {
+                _data->coalesceProviderUse();
+                _data = o._data;
+                _data->bumpProviderUse();
+                _ptr = o._ptr;
+            }
+            return *this;
+        }
+        TPPointer raw () const { return _ptr; }
+
+        inline ThreadPoolProvider *get () const
+        {
+#ifdef ILMBASE_FORCE_CXX03
+            return _ptr;
+#else
+            return _ptr.get();
+#endif
+        }
+        ThreadPoolProvider *operator-> () const
+        {
+            return get();
+        }
+
+        Data *_data;
+        TPPointer _ptr;
+    };
+
+    // NB: In C++20, there is full support for atomic shared_ptr, but that is not
+    // yet in use or finalized. Once stabilized, add appropriate usage here
+    inline SafeProvider getProvider ();
+    inline void coalesceProviderUse ();
+    inline void bumpProviderUse ();
+    inline void setProvider (ThreadPoolProvider *p);
+
+    TPPointer provider;
+#ifdef ILMBASE_FORCE_CXX03
+    Semaphore provSem;
+    Mutex provMutex;
+    int provUsers;
+    TPPointer oldprovider;
+#endif
 };
 
 
 
+namespace {
+
+class DefaultWorkerThread;
+
+struct DefaultWorkData
+{
+    Semaphore taskSemaphore;        // threads wait on this for ready tasks
+    mutable Mutex taskMutex;        // mutual exclusion for the tasks list
+    vector<Task*> tasks;            // the list of tasks to execute
+
+    Semaphore threadSemaphore;      // signaled when a thread starts executing
+    mutable Mutex threadMutex;      // mutual exclusion for threads list
+    vector<DefaultWorkerThread*> threads;  // the list of all threads
+    
+#ifdef ILMBASE_FORCE_CXX03
+    bool stopping;                  // flag indicating whether to stop threads
+    mutable Mutex stopMutex;        // mutual exclusion for stopping flag
+#else
+    std::atomic<bool> hasThreads;
+    std::atomic<bool> stopping;
+#endif
+
+    inline bool stopped () const
+    {
+#ifdef ILMBASE_FORCE_CXX03
+        Lock lock (stopMutex);
+        return stopping;
+#else
+        return stopping.load( std::memory_order_relaxed );
+#endif
+    }
+
+    inline void stop ()
+    {
+#ifdef ILMBASE_FORCE_CXX03
+        Lock lock (stopMutex);
+#endif
+        stopping = true;
+    }
+};
+
 //
 // class WorkerThread
 //
+class DefaultWorkerThread: public Thread
+{
+  public:
 
-WorkerThread::WorkerThread (ThreadPool::Data* data):
+    DefaultWorkerThread (DefaultWorkData* data);
+
+    virtual void    run ();
+    
+  private:
+
+    DefaultWorkData *  _data;
+};
+
+
+DefaultWorkerThread::DefaultWorkerThread (DefaultWorkData* data):
     _data (data)
 {
     start();
@@ -119,7 +217,7 @@ WorkerThread::WorkerThread (ThreadPool::Data* data):
 
 
 void
-WorkerThread::run ()
+DefaultWorkerThread::run ()
 {
     //
     // Signal that the thread has started executing
@@ -129,40 +227,220 @@ WorkerThread::run ()
 
     while (true)
     {
-	//
+        //
         // Wait for a task to become available
-	//
+        //
 
         _data->taskSemaphore.wait();
 
         {
             Lock taskLock (_data->taskMutex);
     
-	    //
+            //
             // If there is a task pending, pop off the next task in the FIFO
-	    //
+            //
 
-            if (_data->numTasks > 0)
+            if (!_data->tasks.empty())
             {
-                Task* task = _data->tasks.front();
-		TaskGroup* taskGroup = task->group();
-                _data->tasks.pop_front();
-                _data->numTasks--;
-
+                Task* task = _data->tasks.back();
+                _data->tasks.pop_back();
                 taskLock.release();
+
+                TaskGroup* taskGroup = task->group();
                 task->execute();
-                taskLock.acquire();
 
                 delete task;
-                taskGroup->_data->removeTask();
+
+                taskGroup->_data->removeTask ();
             }
             else if (_data->stopped())
-	    {
+            {
                 break;
-	    }
+            }
         }
     }
 }
+
+
+//
+// class DefaultThreadPoolProvider
+//
+class DefaultThreadPoolProvider : public ThreadPoolProvider
+{
+  public:
+    DefaultThreadPoolProvider(int count);
+    virtual ~DefaultThreadPoolProvider();
+
+    virtual int numThreads() const;
+    virtual void setNumThreads(int count);
+    virtual void addTask(Task *task);
+
+    virtual void finish();
+
+  private:
+    DefaultWorkData _data;
+};
+
+DefaultThreadPoolProvider::DefaultThreadPoolProvider (int count)
+{
+    setNumThreads(count);
+}
+
+DefaultThreadPoolProvider::~DefaultThreadPoolProvider ()
+{
+    finish();
+}
+
+int
+DefaultThreadPoolProvider::numThreads () const
+{
+    Lock lock (_data.threadMutex);
+    return static_cast<int> (_data.threads.size());
+}
+
+void
+DefaultThreadPoolProvider::setNumThreads (int count)
+{
+    //
+    // Lock access to thread list and size
+    //
+
+    Lock lock (_data.threadMutex);
+
+    size_t desired = static_cast<size_t>(count);
+    if (desired > _data.threads.size())
+    {
+        //
+        // Add more threads
+        //
+
+        while (_data.threads.size() < desired)
+            _data.threads.push_back (new DefaultWorkerThread (&_data));
+    }
+    else if ((size_t)count < _data.threads.size())
+    {
+        //
+        // Wait until all existing threads are finished processing,
+        // then delete all threads.
+        //
+        finish ();
+
+        //
+        // Add in new threads
+        //
+
+        while (_data.threads.size() < desired)
+            _data.threads.push_back (new DefaultWorkerThread (&_data));
+    }
+#ifndef ILMBASE_FORCE_CXX03
+    _data.hasThreads = !(_data.threads.empty());
+#endif
+}
+
+void
+DefaultThreadPoolProvider::addTask (Task *task)
+{
+    //
+    // Lock the threads, needed to access numThreads
+    //
+#ifdef ILMBASE_FORCE_CXX03
+    bool doPush;
+    {
+        Lock lock (_data.threadMutex);
+        doPush = !_data.threads.empty();
+    }
+#else
+    bool doPush = _data.hasThreads.load( std::memory_order_relaxed );
+#endif
+
+    if ( doPush )
+    {
+        //
+        // Get exclusive access to the tasks queue
+        //
+
+        {
+            Lock taskLock (_data.taskMutex);
+
+            //
+            // Push the new task into the FIFO
+            //
+            _data.tasks.push_back (task);
+        }
+        
+        //
+        // Signal that we have a new task to process
+        //
+        _data.taskSemaphore.post ();
+    }
+    else
+    {
+        // this path shouldn't normally happen since we have the
+        // NullThreadPoolProvider, but just in case...
+        task->execute ();
+        task->group()->_data->removeTask ();
+        delete task;
+    }
+}
+
+void
+DefaultThreadPoolProvider::finish ()
+{
+    _data.stop();
+
+    //
+    // Signal enough times to allow all threads to stop.
+    //
+    // Wait until all threads have started their run functions.
+    // If we do not wait before we destroy the threads then it's
+    // possible that the threads have not yet called their run
+    // functions.
+    // If this happens then the run function will be called off
+    // of an invalid object and we will crash, most likely with
+    // an error like: "pure virtual method called"
+    //
+
+    size_t curT = _data.threads.size();
+    for (size_t i = 0; i != curT; ++i)
+    {
+        _data.taskSemaphore.post();
+        _data.threadSemaphore.wait();
+    }
+
+    //
+    // Join all the threads
+    //
+    for (size_t i = 0; i != curT; ++i)
+        delete _data.threads[i];
+
+    Lock lock1 (_data.taskMutex);
+#ifdef ILMBASE_FORCE_CXX03
+    Lock lock2 (_data.stopMutex);
+#endif
+    _data.threads.clear();
+    _data.tasks.clear();
+
+    _data.stopping = false;
+}
+
+
+class NullThreadPoolProvider : public ThreadPoolProvider
+{
+    virtual ~NullThreadPoolProvider() {}
+    virtual int numThreads () const { return 0; }
+    virtual void setNumThreads (int count)
+    {
+    }
+    virtual void addTask (Task *t)
+    {
+        t->execute ();
+        t->group()->_data->removeTask ();
+        delete t;
+    }
+    virtual void finish () {}
+}; 
+
+} //namespace
 
 
 //
@@ -185,6 +463,9 @@ TaskGroup::Data::~Data ()
 
     isEmpty.wait ();
 
+#ifdef ENABLE_SEM_DTOR_WORKAROUND
+    // Update: this was fixed in v. 2.2.21, so this ifdef checks for that
+    //
     // Alas, given the current bug in glibc we need a secondary
     // syncronisation primitive here to account for the fact that
     // destructing the isEmpty Semaphore in this thread can cause
@@ -196,6 +477,7 @@ TaskGroup::Data::~Data ()
     // http://sources.redhat.com/bugzilla/show_bug.cgi?id=12674
 
     Lock lock (dtorMutex);
+#endif
 }
 
 
@@ -203,13 +485,15 @@ void
 TaskGroup::Data::addTask () 
 {
     //
-    // Any access to the taskgroup is protected by a mutex that is
-    // held by the threadpool.  Therefore it is safe to access
-    // numPending before we wait on the semaphore.
+    // in c++11, we use an atomic to protect numPending to avoid the
+    // extra lock but for c++98, to add the ability for custom thread
+    // pool we add the lock here
     //
-
+#if ILMBASE_FORCE_CXX03
+    Lock lock (dtorMutex);
+#endif
     if (numPending++ == 0)
-	isEmpty.wait ();
+        isEmpty.wait ();
 }
 
 
@@ -225,12 +509,29 @@ TaskGroup::Data::removeTask ()
     // Since other threads are entitled to delete the semaphore the
     // access to the memory location can be invalid.
     // http://sources.redhat.com/bugzilla/show_bug.cgi?id=12674
+    // Update: this bug has been fixed, but how do we know which
+    // glibc version we're in?
+
+    // Further update:
+    //
+    // we could remove this if it is a new enough glibc, however 
+    // we've changed the API to enable a custom override of a
+    // thread pool. In order to provide safe access to the numPending,
+    // we need the lock anyway, except for c++11 or newer
+#ifdef ILMBASE_FORCE_CXX03
+    Lock lock (dtorMutex);
 
     if (--numPending == 0)
+        isEmpty.post ();
+#else
+    if (--numPending == 0)
     {
+#ifdef ENABLE_SEM_DTOR_WORKAROUND
         Lock lock (dtorMutex);
+#endif
         isEmpty.post ();
     }
+#endif
 }
     
 
@@ -238,7 +539,10 @@ TaskGroup::Data::removeTask ()
 // struct ThreadPool::Data
 //
 
-ThreadPool::Data::Data (): numTasks (0), numThreads (0), stopping (false)
+ThreadPool::Data::Data (): provider (NULL)
+#ifdef ILMBASE_FORCE_CXX03
+                         , provUsers (0), oldprovider (NULL)
+#endif
 {
     // empty
 }
@@ -246,70 +550,84 @@ ThreadPool::Data::Data (): numTasks (0), numThreads (0), stopping (false)
 
 ThreadPool::Data::~Data()
 {
-    Lock lock (threadMutex);
-    finish ();
+    provider->finish();
+}
+
+inline ThreadPool::Data::SafeProvider
+ThreadPool::Data::getProvider ()
+{
+#ifdef ILMBASE_FORCE_CXX03
+    Lock provLock( provMutex );
+    ++provUsers;
+    return SafeProvider( this, provider );
+#else
+    return SafeProvider( this, std::atomic_load_explicit( &provider, std::memory_order_relaxed ) );
+#endif
 }
 
 
-void
-ThreadPool::Data::finish ()
+inline void
+ThreadPool::Data::coalesceProviderUse ()
 {
-    stop();
-
-    //
-    // Signal enough times to allow all threads to stop.
-    //
-    // Wait until all threads have started their run functions.
-    // If we do not wait before we destroy the threads then it's
-    // possible that the threads have not yet called their run
-    // functions.
-    // If this happens then the run function will be called off
-    // of an invalid object and we will crash, most likely with
-    // an error like: "pure virtual method called"
-    //
-
-    for (size_t i = 0; i < numThreads; i++)
+#ifdef ILMBASE_FORCE_CXX03
+    Lock provLock( provMutex );
+    --provUsers;
+    if ( provUsers == 0 )
     {
-	taskSemaphore.post();
-	threadSemaphore.wait();
+        if ( oldprovider )
+            provSem.post();
     }
+#endif
+}
 
-    //
-    // Join all the threads
-    //
 
-    for (list<WorkerThread*>::iterator i = threads.begin();
-	 i != threads.end();
-	 ++i)
+inline void
+ThreadPool::Data::bumpProviderUse ()
+{
+#ifdef ILMBASE_FORCE_CXX03
+    Lock lock (provMutex);
+    ++provUsers;
+#endif
+}
+
+
+inline void
+ThreadPool::Data::setProvider (ThreadPoolProvider *p)
+{
+#ifdef ILMBASE_FORCE_CXX03
+    Lock provLock( provMutex );
+
+    if ( oldprovider )
+        throw IEX_INTERNAL_NAMESPACE::ArgExc ("Attempt to set the thread pool provider while"
+                                              " another thread is currently setting the provider.");
+
+    oldprovider = provider;
+    provider = p;
+
+    while ( provUsers > 0 )
     {
-	delete (*i);
+        provLock.release();
+        provSem.wait();
+        provLock.acquire();
     }
-
-    Lock lock1 (taskMutex);
-    Lock lock2 (stopMutex);
-    threads.clear();
-    tasks.clear();
-    numThreads = 0;
-    numTasks = 0;
-    stopping = false;
+    if ( oldprovider )
+    {
+        oldprovider->finish();
+        delete oldprovider;
+        oldprovider = NULL;
+    }
+#else
+    std::shared_ptr<ThreadPoolProvider> newp( p );
+    std::shared_ptr<ThreadPoolProvider> curp = std::atomic_load_explicit( &provider, std::memory_order_relaxed );
+    do
+    {
+        if ( ! std::atomic_compare_exchange_weak_explicit( &provider, &curp, newp, std::memory_order_release, std::memory_order_relaxed ) )
+            continue;
+    } while ( false );
+    if ( curp )
+        curp->finish();
+#endif
 }
-
-
-bool
-ThreadPool::Data::stopped () const
-{
-    Lock lock (stopMutex);
-    return stopping;
-}
-
-
-void
-ThreadPool::Data::stop ()
-{
-    Lock lock (stopMutex);
-    stopping = true;
-}
-
 
 //
 // class Task
@@ -317,7 +635,8 @@ ThreadPool::Data::stop ()
 
 Task::Task (TaskGroup* g): _group(g)
 {
-    // empty
+    if ( g )
+        g->_data->addTask ();
 }
 
 
@@ -347,14 +666,38 @@ TaskGroup::~TaskGroup ()
 }
 
 
+void
+TaskGroup::finishOneTask ()
+{
+    _data->removeTask ();
+}
+
+//
+// class ThreadPoolProvider
+//
+
+
+ThreadPoolProvider::ThreadPoolProvider()
+{
+}
+
+
+ThreadPoolProvider::~ThreadPoolProvider()
+{
+}
+
+
 //
 // class ThreadPool
 //
 
 ThreadPool::ThreadPool (unsigned nthreads):
-    _data (new Data())
+    _data (new Data)
 {
-    setNumThreads (nthreads);
+    if ( nthreads == 0 )
+        _data->setProvider( new NullThreadPoolProvider );
+    else
+        _data->setProvider( new DefaultThreadPoolProvider( int(nthreads) ) );
 }
 
 
@@ -367,8 +710,7 @@ ThreadPool::~ThreadPool ()
 int
 ThreadPool::numThreads () const
 {
-    Lock lock (_data->threadMutex);
-    return _data->numThreads;
+    return _data->getProvider ()->numThreads ();
 }
 
 
@@ -377,86 +719,52 @@ ThreadPool::setNumThreads (int count)
 {
     if (count < 0)
         throw IEX_INTERNAL_NAMESPACE::ArgExc ("Attempt to set the number of threads "
-			   "in a thread pool to a negative value.");
+               "in a thread pool to a negative value.");
 
-    //
-    // Lock access to thread list and size
-    //
-
-    Lock lock (_data->threadMutex);
-
-    if ((size_t)count > _data->numThreads)
+    bool doReset = false;
     {
-	//
-        // Add more threads
-	//
+        Data::SafeProvider sp = _data->getProvider ();
+        int curT = sp->numThreads ();
+        if ( curT == count )
+            return;
 
-        while (_data->numThreads < (size_t)count)
+        if ( curT == 0 )
         {
-            _data->threads.push_back (new WorkerThread (_data));
-            _data->numThreads++;
+            NullThreadPoolProvider *npp = dynamic_cast<NullThreadPoolProvider *>( sp.get() );
+            if ( npp )
+                doReset = true;
         }
+        else if ( count == 0 )
+        {
+            DefaultThreadPoolProvider *dpp = dynamic_cast<DefaultThreadPoolProvider *>( sp.get() );
+            if ( dpp )
+                doReset = true;
+        }
+        if ( ! doReset )
+            sp->setNumThreads( count );
     }
-    else if ((size_t)count < _data->numThreads)
+
+    if ( doReset )
     {
-	//
-	// Wait until all existing threads are finished processing,
-	// then delete all threads.
-	//
-
-        _data->finish ();
-
-	//
-        // Add in new threads
-	//
-
-        while (_data->numThreads < (size_t)count)
-        {
-            _data->threads.push_back (new WorkerThread (_data));
-            _data->numThreads++;
-        }
+        if ( count == 0 )
+            _data->setProvider( new NullThreadPoolProvider );
+        else
+            _data->setProvider( new DefaultThreadPoolProvider( count ) );
     }
+}
+
+
+void
+ThreadPool::setThreadProvider (ThreadPoolProvider *provider)
+{
+    _data->setProvider (provider);
 }
 
 
 void
 ThreadPool::addTask (Task* task) 
 {
-    //
-    // Lock the threads, needed to access numThreads
-    //
-
-    Lock lock (_data->threadMutex);
-
-    if (_data->numThreads == 0)
-    {
-        task->execute ();
-        delete task;
-    }
-    else
-    {
-	//
-        // Get exclusive access to the tasks queue
-	//
-
-        {
-            Lock taskLock (_data->taskMutex);
-
-	    //
-            // Push the new task into the FIFO
-	    //
-
-            _data->tasks.push_back (task);
-            _data->numTasks++;
-            task->group()->_data->addTask();
-        }
-        
-	//
-        // Signal that we have a new task to process
-	//
-
-        _data->taskSemaphore.post ();
-    }
+    _data->getProvider ()->addTask (task);
 }
 
 

--- a/IlmBase/IlmThread/IlmThreadPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadPosix.cpp
@@ -42,6 +42,7 @@
 #include "IlmBaseConfig.h"
 
 #if HAVE_PTHREAD
+#ifdef ILMBASE_FORCE_CXX03
 
 #include "IlmThread.h"
 #include "Iex.h"
@@ -95,4 +96,5 @@ Thread::start ()
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#endif
 #endif

--- a/IlmBase/IlmThread/IlmThreadSemaphore.h
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.h
@@ -47,15 +47,22 @@
 #include "IlmThreadNamespace.h"
 
 #if defined _WIN32 || defined _WIN64
-    #ifdef NOMINMAX
-        #undef NOMINMAX
-    #endif
-    #define NOMINMAX
-    #include <windows.h>
-#elif HAVE_PTHREAD && !HAVE_POSIX_SEMAPHORES
-    #include <pthread.h>
-#elif HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
-    #include <semaphore.h>
+#   ifdef NOMINMAX
+#      undef NOMINMAX
+#   endif
+#   define NOMINMAX
+#   include <windows.h>
+#elif HAVE_POSIX_SEMAPHORES
+#   include <semaphore.h>
+#else
+#   ifdef ILMBASE_FORCE_CXX03
+#      if HAVE_PTHREAD
+#         include <pthread.h>
+#      endif
+#   else
+#      include <mutex>
+#      include <condition_variable>
+#   endif
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -75,12 +82,15 @@ class ILMTHREAD_EXPORT Semaphore
 
   private:
 
-    #if defined _WIN32 || defined _WIN64
+#if defined _WIN32 || defined _WIN64
 
 	mutable HANDLE _semaphore;
 
-    #elif HAVE_PTHREAD && !HAVE_POSIX_SEMAPHORES
+#elif defined(HAVE_POSIX_SEMAPHORES)
 
+	mutable sem_t _semaphore;
+
+#else
 	//
 	// If the platform has Posix threads but no semapohores,
 	// then we implement them ourselves using condition variables
@@ -90,17 +100,22 @@ class ILMTHREAD_EXPORT Semaphore
 	{
 	    unsigned int count;
 	    unsigned long numWaiting;
+#   if ILMBASE_FORCE_CXX03
+#      if HAVE_PTHREAD
 	    pthread_mutex_t mutex;
 	    pthread_cond_t nonZero;
+#      else
+#         error unhandled legacy setup
+#      endif
+#   else
+        std::mutex mutex;
+        std::condition_variable nonZero;
+#   endif
 	};
 
 	mutable sema_t _semaphore;
-
-    #elif HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
-
-	mutable sem_t _semaphore;
-
-    #endif
+  
+#endif
 
     void operator = (const Semaphore& s);	// not implemented
     Semaphore (const Semaphore& s);		// not implemented

--- a/IlmBase/IlmThread/IlmThreadWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadWin32.cpp
@@ -39,6 +39,10 @@
 //-----------------------------------------------------------------------------
 
 
+#include "IlmBaseConfig.h"
+
+#ifdef ILMBASE_FORCE_CXX03
+
 #include "IlmThread.h"
 #include "Iex.h"
 #include <iostream>
@@ -93,3 +97,5 @@ Thread::start ()
 
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
+
+#endif

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -263,16 +263,16 @@ template <class T> class Matrix33
     //------------------------------------------------------------
 
     const Matrix33 &    invert (bool singExc = false)
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     Matrix33<T>         inverse (bool singExc = false) const
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     const Matrix33 &    gjInvert (bool singExc = false)
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     Matrix33<T>         gjInverse (bool singExc = false) const
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 
     //------------------------------------------------
@@ -637,16 +637,16 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     const Matrix44 &    invert (bool singExc = false)
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     Matrix44<T>         inverse (bool singExc = false) const
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     const Matrix44 &    gjInvert (bool singExc = false)
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
     Matrix44<T>         gjInverse (bool singExc = false) const
-                        throw (IEX_NAMESPACE::MathExc);
+                        IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 
     //------------------------------------------------
@@ -1430,7 +1430,7 @@ Matrix33<T>::transposed () const
 
 template <class T>
 const Matrix33<T> &
-Matrix33<T>::gjInvert (bool singExc) throw (IEX_NAMESPACE::MathExc)
+Matrix33<T>::gjInvert (bool singExc) IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     *this = gjInverse (singExc);
     return *this;
@@ -1438,7 +1438,7 @@ Matrix33<T>::gjInvert (bool singExc) throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 Matrix33<T>
-Matrix33<T>::gjInverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
+Matrix33<T>::gjInverse (bool singExc) const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     int i, j, k;
     Matrix33 s;
@@ -1542,7 +1542,7 @@ Matrix33<T>::gjInverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 const Matrix33<T> &
-Matrix33<T>::invert (bool singExc) throw (IEX_NAMESPACE::MathExc)
+Matrix33<T>::invert (bool singExc) IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     *this = inverse (singExc);
     return *this;
@@ -1550,7 +1550,7 @@ Matrix33<T>::invert (bool singExc) throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 Matrix33<T>
-Matrix33<T>::inverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
+Matrix33<T>::inverse (bool singExc) const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
     {
@@ -2699,7 +2699,7 @@ Matrix44<T>::transposed () const
 
 template <class T>
 const Matrix44<T> &
-Matrix44<T>::gjInvert (bool singExc) throw (IEX_NAMESPACE::MathExc)
+Matrix44<T>::gjInvert (bool singExc) IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     *this = gjInverse (singExc);
     return *this;
@@ -2707,7 +2707,7 @@ Matrix44<T>::gjInvert (bool singExc) throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 Matrix44<T>
-Matrix44<T>::gjInverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
+Matrix44<T>::gjInverse (bool singExc) const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     int i, j, k;
     Matrix44 s;
@@ -2811,7 +2811,7 @@ Matrix44<T>::gjInverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 const Matrix44<T> &
-Matrix44<T>::invert (bool singExc) throw (IEX_NAMESPACE::MathExc)
+Matrix44<T>::invert (bool singExc) IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     *this = inverse (singExc);
     return *this;
@@ -2819,7 +2819,7 @@ Matrix44<T>::invert (bool singExc) throw (IEX_NAMESPACE::MathExc)
 
 template <class T>
 Matrix44<T>
-Matrix44<T>::inverse (bool singExc) const throw (IEX_NAMESPACE::MathExc)
+Matrix44<T>::inverse (bool singExc) const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
         return gjInverse(singExc);

--- a/IlmBase/Imath/ImathVec.cpp
+++ b/IlmBase/Imath/ImathVec.cpp
@@ -149,7 +149,7 @@ Vec2<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec2<short> &
-Vec2<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -180,7 +180,7 @@ Vec2<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec2<short>
-Vec2<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -225,7 +225,7 @@ Vec2<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec2<int> &
-Vec2<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -256,7 +256,7 @@ Vec2<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec2<int>
-Vec2<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -301,7 +301,7 @@ Vec3<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec3<short> &
-Vec3<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -332,7 +332,7 @@ Vec3<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec3<short>
-Vec3<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -377,7 +377,7 @@ Vec3<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec3<int> &
-Vec3<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -408,7 +408,7 @@ Vec3<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec3<int>
-Vec3<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -453,7 +453,7 @@ Vec4<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec4<short> &
-Vec4<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -484,7 +484,7 @@ Vec4<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec4<short>
-Vec4<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -529,7 +529,7 @@ Vec4<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec4<int> &
-Vec4<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -560,7 +560,7 @@ Vec4<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec4<int>
-Vec4<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");

--- a/IlmBase/Imath/ImathVec.h
+++ b/IlmBase/Imath/ImathVec.h
@@ -225,11 +225,11 @@ template <class T> class Vec2
     T			length2 () const;
 
     const Vec2 &	normalize ();           // modifies *this
-    const Vec2 &	normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec2 &	normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     const Vec2 &	normalizeNonNull ();
 
     Vec2<T>		normalized () const;	// does not modify *this
-    Vec2<T>		normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec2<T>		normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     Vec2<T>		normalizedNonNull () const;
 
 
@@ -437,11 +437,11 @@ template <class T> class Vec3
     T			length2 () const;
 
     const Vec3 &	normalize ();           // modifies *this
-    const Vec3 &	normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec3 &	normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     const Vec3 &	normalizeNonNull ();
 
     Vec3<T>		normalized () const;	// does not modify *this
-    Vec3<T>		normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec3<T>		normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     Vec3<T>		normalizedNonNull () const;
 
 
@@ -619,11 +619,11 @@ template <class T> class Vec4
     T               length2 () const;
 
     const Vec4 &    normalize ();           // modifies *this
-    const Vec4 &    normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec4 &    normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     const Vec4 &    normalizeNonNull ();
 
     Vec4<T>         normalized () const;	// does not modify *this
-    Vec4<T>         normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec4<T>         normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
     Vec4<T>         normalizedNonNull () const;
 
 
@@ -711,7 +711,7 @@ template <> const Vec2<short> &
 Vec2<short>::normalize ();
 
 template <> const Vec2<short> &
-Vec2<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec2<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec2<short> &
 Vec2<short>::normalizeNonNull ();
@@ -720,7 +720,7 @@ template <> Vec2<short>
 Vec2<short>::normalized () const;
 
 template <> Vec2<short>
-Vec2<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec2<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec2<short>
 Vec2<short>::normalizedNonNull () const;
@@ -735,7 +735,7 @@ template <> const Vec2<int> &
 Vec2<int>::normalize ();
 
 template <> const Vec2<int> &
-Vec2<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec2<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec2<int> &
 Vec2<int>::normalizeNonNull ();
@@ -744,7 +744,7 @@ template <> Vec2<int>
 Vec2<int>::normalized () const;
 
 template <> Vec2<int>
-Vec2<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec2<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec2<int>
 Vec2<int>::normalizedNonNull () const;
@@ -759,7 +759,7 @@ template <> const Vec3<short> &
 Vec3<short>::normalize ();
 
 template <> const Vec3<short> &
-Vec3<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec3<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec3<short> &
 Vec3<short>::normalizeNonNull ();
@@ -768,7 +768,7 @@ template <> Vec3<short>
 Vec3<short>::normalized () const;
 
 template <> Vec3<short>
-Vec3<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec3<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec3<short>
 Vec3<short>::normalizedNonNull () const;
@@ -783,7 +783,7 @@ template <> const Vec3<int> &
 Vec3<int>::normalize ();
 
 template <> const Vec3<int> &
-Vec3<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec3<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec3<int> &
 Vec3<int>::normalizeNonNull ();
@@ -792,7 +792,7 @@ template <> Vec3<int>
 Vec3<int>::normalized () const;
 
 template <> Vec3<int>
-Vec3<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec3<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec3<int>
 Vec3<int>::normalizedNonNull () const;
@@ -806,7 +806,7 @@ template <> const Vec4<short> &
 Vec4<short>::normalize ();
 
 template <> const Vec4<short> &
-Vec4<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec4<short>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec4<short> &
 Vec4<short>::normalizeNonNull ();
@@ -815,7 +815,7 @@ template <> Vec4<short>
 Vec4<short>::normalized () const;
 
 template <> Vec4<short>
-Vec4<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec4<short>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec4<short>
 Vec4<short>::normalizedNonNull () const;
@@ -830,7 +830,7 @@ template <> const Vec4<int> &
 Vec4<int>::normalize ();
 
 template <> const Vec4<int> &
-Vec4<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec4<int>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> const Vec4<int> &
 Vec4<int>::normalizeNonNull ();
@@ -839,7 +839,7 @@ template <> Vec4<int>
 Vec4<int>::normalized () const;
 
 template <> Vec4<int>
-Vec4<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec4<int>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc);
 
 template <> Vec4<int>
 Vec4<int>::normalizedNonNull () const;
@@ -1209,7 +1209,7 @@ Vec2<T>::normalize ()
 
 template <class T>
 const Vec2<T> &
-Vec2<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<T>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 
@@ -1246,7 +1246,7 @@ Vec2<T>::normalized () const
 
 template <class T>
 Vec2<T>
-Vec2<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<T>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 
@@ -1701,7 +1701,7 @@ Vec3<T>::normalize ()
 
 template <class T>
 const Vec3<T> &
-Vec3<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<T>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 
@@ -1740,7 +1740,7 @@ Vec3<T>::normalized () const
 
 template <class T>
 Vec3<T>
-Vec3<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<T>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 
@@ -2106,7 +2106,7 @@ Vec4<T>::normalize ()
 
 template <class T>
 const Vec4<T> &
-Vec4<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<T>::normalizeExc () IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 
@@ -2147,7 +2147,7 @@ Vec4<T>::normalized () const
 
 template <class T>
 Vec4<T>
-Vec4<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<T>::normalizedExc () const IEX_THROW_SPEC (IEX_NAMESPACE::MathExc)
 {
     T l = length();
 

--- a/IlmBase/config/IlmBaseConfig.h.in
+++ b/IlmBase/config/IlmBaseConfig.h.in
@@ -1,4 +1,11 @@
 //
+// Define and set to 1 if the target system has c++11/14 support
+// and you want IlmBase to NOT use it's features
+//
+
+#undef ILMBASE_FORCE_CXX03
+
+//
 // Define and set to 1 if the target system has POSIX thread support
 // and you want IlmBase to use it for multithreaded file I/O.
 //

--- a/IlmBase/configure.ac
+++ b/IlmBase/configure.ac
@@ -39,6 +39,21 @@ fi
 
 export PKG_CONFIG_PATH
 
+AC_ARG_ENABLE(cxx14,
+              AC_HELP_STRING([--enable-cxx14],
+                             [enable c++11/14 [[default=auto]]]),
+              [cxx14="${enableval}"], [cxx14=yes])
+			  
+if test "${cxx14}" != no ; then
+    AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
+	CXXFLAGS="$CXXFLAGS -std=c++14"
+else
+    AC_DEFINE(ILMBASE_FORCE_CXX03)
+    AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+    if test "${HAVE_CXX11}" != no ; then
+        CXXFLAGS="$CXXFLAGS -std=c++03"
+    fi
+fi
 
 dnl Checks for libraries.
 dnl --enable-threading

--- a/IlmBase/configure.ac
+++ b/IlmBase/configure.ac
@@ -39,20 +39,43 @@ fi
 
 export PKG_CONFIG_PATH
 
-AC_ARG_ENABLE(cxx14,
-              AC_HELP_STRING([--enable-cxx14],
-                             [enable c++11/14 [[default=auto]]]),
-              [cxx14="${enableval}"], [cxx14=yes])
-			  
-if test "${cxx14}" != no ; then
-    AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
-	CXXFLAGS="$CXXFLAGS -std=c++14"
+AC_ARG_ENABLE(cxxstd,
+              AC_HELP_STRING([--enable-cxxstd=14],
+                             [enable ISO c++ standard 11/14 [[default=auto]]]),
+              [cxxstd="${enableval}"], [cxxstd=14])
+
+if test "${cxxstd}" == 17 ; then
+    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+	CXXFLAGS="$CXXFLAGS -std=c++17"
 else
-    AC_DEFINE(ILMBASE_FORCE_CXX03)
-    AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
-    if test "${HAVE_CXX11}" != no ; then
+  if test "${cxxstd}" == 14 ; then
+      AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
+  	CXXFLAGS="$CXXFLAGS -std=c++14"
+  else
+    if test "${cxxstd}" == 11 ; then
+      AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+      CXXFLAGS="$CXXFLAGS -std=c++11"
+    else
+      if test "${cxxstd}" == 03 ; then
+        AC_DEFINE(ILMBASE_FORCE_CXX03)
         CXXFLAGS="$CXXFLAGS -std=c++03"
+      else
+        dnl automatically determine...
+        AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
+        if test "$HAVE_CXX14" == 1 ; then
+  	      CXXFLAGS="$CXXFLAGS -std=c++14"
+          cxxstd = 14
+        else
+          if test "$HAVE_CXX11" == 1 ; then
+  	        CXXFLAGS="$CXXFLAGS -std=c++11"
+            cxxstd = 11
+          fi
+        fi
+      fi
     fi
+  fi
 fi
 
 dnl Checks for libraries.
@@ -348,7 +371,8 @@ dnl
 AC_MSG_RESULT([
 ---------------------------------------------
 Summary for IlmBase features:
-enable large stack optimizations             $large_stack])
+enable large stack optimizations             $large_stack
+ISO C++ Standard                             $cxxstd])
   
 if test "x${library_namespace_versioning}" != xno ; then
   AC_MSG_RESULT([

--- a/IlmBase/m4/ax_cxx_compile_stdcxx.m4
+++ b/IlmBase/m4/ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,982 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
+#   or '14' (for the C++14 standard).
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016 Krzesimir Nowak <qdlacz@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AX_REQUIRE_DEFINED([AC_MSG_WARN])
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+  ax_cv_cxx_compile_cxx$1,
+  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+    [ax_cv_cxx_compile_cxx$1=yes],
+    [ax_cv_cxx_compile_cxx$1=no])])
+  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+    ac_success=yes
+  fi
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+  m4_if([$1], [17], [AC_MSG_WARN([C++17 is not yet standardized, so the checks may change in incompatible ways anytime])])
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+)
+
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+)
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201103L
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus <= 201402L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#if defined(__clang__)
+  #define REALLY_CLANG
+#else
+  #if defined(__GNUC__)
+    #define REALLY_GCC
+  #endif
+#endif
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+#if !defined(REALLY_CLANG)
+  namespace test_constexpr_lambdas
+  {
+
+    // TODO: test it with clang++ from git
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+#if !defined(REALLY_CLANG)
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    // TODO: test it with clang++ from git
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+#if !defined(REALLY_CLANG)
+  namespace test_structured_bindings
+  {
+
+    // TODO: test it with clang++ from git
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+#if !defined(REALLY_CLANG)
+  namespace test_exception_spec_type_system
+  {
+
+    // TODO: test it with clang++ from git
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+#endif // !defined(REALLY_CLANG)
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus <= 201402L
+
+]])


### PR DESCRIPTION
Given VP18 is c++14, this is a few commits that enable c++14 in both cmake and autoconf, with a mechanism to disable and force IlmBase to continue to be strictly c++03 compliant.

Credit / Other pull request notes: I started this to add the thread pool optimizations, which we would like. However, this should be considered an alternate implementation of pull request #55 , and I didn't realize it at the time, but provides similar c++11 related dynamic exception fixes as #93, #236, and #243 , so there might be conflicts there. Finally, this should make #170 obsolete with a more complete fix - it would appear @lgritz and I have similar perf traces for loading tiles... :)

Includes:
- configure / cmake changes
- dynamic exception macro to fix compile warnings in Imath
- IlmThread enables use of std::thread, std::mutex
- ThreadPool uses c++11 atomic, shared_ptr (when enabled) to provide lighter weight thread safe contention when appropriate, cleanups, and reducing lock contention in both scenarios
- At the same time, an API to enable a user to replace the global thread pool is proposed, with no change to existing API, only additions. This is used internally to provide a minimal overhead, completely lock-free task processing when numThreads is set to 0 (which also happens to be the default for the OpenEXR library)
- A std::condition_variable based Semaphore is available when in c++11 mode

note: I did NOT switch semaphore to only use std::condition_variable/std::mutex - only when semaphores are not available. low level semaphores tend to be faster when dispatching things in a sequence, as this pool tends to do, so blindly switching to condition_variable should only be done when semaphores are not available...
