### PR TITLE
add move constructor and assignment operator

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -99,9 +99,25 @@ class SimdAlignedBuffer64
             return *this;
         }
 
+#if __cplusplus >= 201103L
+        SimdAlignedBuffer64(SimdAlignedBuffer64 &&rhs) noexcept
+            : _handle(rhs._handle), _buffer(rhs._buffer)
+        {
+            rhs._handle = nullptr;
+            rhs._buffer = nullptr;
+        }
+
+        SimdAlignedBuffer64 &operator=(SimdAlignedBuffer64 &&rhs) noexcept
+        {
+            std::swap(_handle, rhs._handle);
+            std::swap(_buffer, rhs._buffer);
+            return *this;
+        }
+#endif
         ~SimdAlignedBuffer64 ()
         {
-            EXRFreeAligned (_handle);
+            if (_handle)
+                EXRFreeAligned (_handle);
             _handle = 0;
             _buffer = 0;
         }


### PR DESCRIPTION
This builds on a previous patch and adds move operators for the dwa simd buffer