### PR TITLE
replicate configure / cmake changes from ilmbase

### DIFF
--- a/IlmBase/configure.ac
+++ b/IlmBase/configure.ac
@@ -39,6 +39,7 @@ fi
 
 export PKG_CONFIG_PATH
 
+dnl Enable and choose c++ standard
 AC_ARG_ENABLE(cxxstd,
               AC_HELP_STRING([--enable-cxxstd=14],
                              [enable ISO c++ standard 11/14 [[default=auto]]]),

--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -33,6 +33,16 @@ OPTION (BUILD_SHARED_LIBS    "Build Shared Libraries" ON)
 OPTION (USE_ZLIB_WINAPI      "Use ZLib Win API"       OFF)
 OPTION (NAMESPACE_VERSIONING "Use Namespace Versioning" ON)
 
+OPTION (FORCE_CXX03 "Force CXX03" OFF)
+IF (FORCE_CXX03)
+  ADD_DEFINITIONS ( -std=c++03 )
+ELSE (FORCE_CXX03)
+  # VP18 switches to c++14, so let's do that by default
+  SET(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
+  # but switch gnu++14 or other extensions off for portability
+  SET(CMAKE_CXX_EXTENSIONS OFF)
+ENDIF ()
+
 # Setup osx rpathing
 SET (CMAKE_MACOSX_RPATH 1)
 SET (BUILD_WITH_INSTALL_RPATH 1)

--- a/OpenEXR/IlmImf/ImfAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfAttribute.cpp
@@ -88,6 +88,11 @@ class LockedTypeMap: public TypeMap
 LockedTypeMap &
 typeMap ()
 {
+    // c++11 requires thread-safe static variable initialization
+#if __cplusplus >= 201103L
+    static LockedTypeMap tMap;
+    return tMap;
+#else
     static Mutex criticalSection;
     Lock lock (criticalSection);
 
@@ -97,6 +102,7 @@ typeMap ()
 	typeMap = new LockedTypeMap ();
 
     return *typeMap;
+#endif
 }
 
 

--- a/OpenEXR/bootstrap
+++ b/OpenEXR/bootstrap
@@ -51,7 +51,7 @@ if [ -d /usr/local/share/aclocal ]; then
 	ACLOCAL_INCLUDE="$ACLOCAL_INCLUDE -I /usr/local/share/aclocal"
 fi	
 
-run_cmd aclocal -I m4 $ACLOCAL_INCLUDE
+run_cmd aclocal -I m4 -I ../IlmBase/m4 $ACLOCAL_INCLUDE
 run_cmd $LIBTOOLIZE --automake --copy
 run_cmd automake --add-missing --copy
 run_cmd autoconf

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -68,6 +68,45 @@ AC_DEFINE_UNQUOTED(OPENEXR_VERSION_MAJOR, ${OPENEXR_VERSION_MAJOR})
 AC_DEFINE_UNQUOTED(OPENEXR_VERSION_MINOR, ${OPENEXR_VERSION_MINOR})
 AC_DEFINE_UNQUOTED(OPENEXR_VERSION_PATCH, ${OPENEXR_VERSION_PATCH})
 
+dnl Enable and choose c++ standard
+AC_ARG_ENABLE(cxxstd,
+              AC_HELP_STRING([--enable-cxxstd=14],
+                             [enable ISO c++ standard 11/14 [[default=auto]]]),
+              [cxxstd="${enableval}"], [cxxstd=14])
+
+if test "${cxxstd}" == 17 ; then
+    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+	CXXFLAGS="$CXXFLAGS -std=c++17"
+else
+  if test "${cxxstd}" == 14 ; then
+      AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
+  	CXXFLAGS="$CXXFLAGS -std=c++14"
+  else
+    if test "${cxxstd}" == 11 ; then
+      AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+      CXXFLAGS="$CXXFLAGS -std=c++11"
+    else
+      if test "${cxxstd}" == 03 ; then
+        AC_DEFINE(ILMBASE_FORCE_CXX03)
+        CXXFLAGS="$CXXFLAGS -std=c++03"
+      else
+        dnl automatically determine...
+        AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
+        if test "$HAVE_CXX14" == 1 ; then
+  	      CXXFLAGS="$CXXFLAGS -std=c++14"
+          cxxstd = 14
+        else
+          if test "$HAVE_CXX11" == 1 ; then
+  	        CXXFLAGS="$CXXFLAGS -std=c++11"
+            cxxstd = 11
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
 
 dnl --enable-threading
 AC_ARG_ENABLE(threading,

--- a/OpenEXR_Viewers/CMakeLists.txt
+++ b/OpenEXR_Viewers/CMakeLists.txt
@@ -24,6 +24,16 @@ INCLUDE ( CPack )
 
 OPTION (NAMESPACE_VERSIONING "Use Namespace Versioning" ON)
 
+OPTION (FORCE_CXX03 "Force CXX03" OFF)
+IF (FORCE_CXX03)
+  ADD_DEFINITIONS ( -std=c++03 )
+ELSE (FORCE_CXX03)
+  # VP18 switches to c++14, so let's do that by default
+  SET(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
+  # but switch gnu++14 or other extensions off for portability
+  SET(CMAKE_CXX_EXTENSIONS OFF)
+ENDIF ()
+
 # Setup osx rpathing
 SET (CMAKE_MACOSX_RPATH 1)
 SET (BUILD_WITH_INSTALL_RPATH 1)

--- a/OpenEXR_Viewers/bootstrap
+++ b/OpenEXR_Viewers/bootstrap
@@ -52,7 +52,7 @@ if [ -d /usr/local/share/aclocal ]; then
 	ACLOCAL_INCLUDE="$ACLOCAL_INCLUDE -I /usr/local/share/aclocal"
 fi	
 
-run_cmd aclocal -I m4 $ACLOCAL_INCLUDE
+run_cmd aclocal -I m4 -I ../IlmBase/m4 $ACLOCAL_INCLUDE
 run_cmd $LIBTOOLIZE --automake --copy
 run_cmd automake --add-missing --copy
 run_cmd autoconf

--- a/OpenEXR_Viewers/configure.ac
+++ b/OpenEXR_Viewers/configure.ac
@@ -78,6 +78,46 @@ AM_PATH_PKGCONFIG(
    [openexrctl-prefix])
 
 
+dnl Enable and choose c++ standard
+AC_ARG_ENABLE(cxxstd,
+              AC_HELP_STRING([--enable-cxxstd=14],
+                             [enable ISO c++ standard 11/14 [[default=auto]]]),
+              [cxxstd="${enableval}"], [cxxstd=14])
+
+if test "${cxxstd}" == 17 ; then
+    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+	CXXFLAGS="$CXXFLAGS -std=c++17"
+else
+  if test "${cxxstd}" == 14 ; then
+      AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
+  	CXXFLAGS="$CXXFLAGS -std=c++14"
+  else
+    if test "${cxxstd}" == 11 ; then
+      AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+      CXXFLAGS="$CXXFLAGS -std=c++11"
+    else
+      if test "${cxxstd}" == 03 ; then
+        AC_DEFINE(ILMBASE_FORCE_CXX03)
+        CXXFLAGS="$CXXFLAGS -std=c++03"
+      else
+        dnl automatically determine...
+        AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
+        if test "$HAVE_CXX14" == 1 ; then
+  	      CXXFLAGS="$CXXFLAGS -std=c++14"
+          cxxstd = 14
+        else
+          if test "$HAVE_CXX11" == 1 ; then
+  	        CXXFLAGS="$CXXFLAGS -std=c++11"
+            cxxstd = 11
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
 dnl --enable-threading
 AC_ARG_ENABLE(threading,
               AC_HELP_STRING([--enable-threading],

--- a/PyIlmBase/CMakeLists.txt
+++ b/PyIlmBase/CMakeLists.txt
@@ -32,6 +32,16 @@ OPTION (NAMESPACE_VERSIONING "Use Namespace Versioning" ON)
 # Allow the developer to select if Dynamic or Static libraries are built
 OPTION (BUILD_SHARED_LIBS    "Build Shared Libraries" ON)
 
+OPTION (FORCE_CXX03 "Force CXX03" OFF)
+IF (FORCE_CXX03)
+  ADD_DEFINITIONS ( -std=c++03 )
+ELSE (FORCE_CXX03)
+  # VP18 switches to c++14, so let's do that by default
+  SET(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
+  # but switch gnu++14 or other extensions off for portability
+  SET(CMAKE_CXX_EXTENSIONS OFF)
+ENDIF ()
+
 # Setup osx rpathing
 SET (CMAKE_MACOSX_RPATH 1)
 SET (BUILD_WITH_INSTALL_RPATH 1)

--- a/PyIlmBase/bootstrap
+++ b/PyIlmBase/bootstrap
@@ -52,7 +52,7 @@ if [ -d /usr/local/share/aclocal ]; then
 	ACLOCAL_INCLUDE="$ACLOCAL_INCLUDE -I /usr/local/share/aclocal"
 fi	
 
-run_cmd aclocal -I m4 $ACLOCAL_INCLUDE
+run_cmd aclocal -I m4 -I ../IlmBase/m4 $ACLOCAL_INCLUDE
 run_cmd $LIBTOOLIZE --automake --copy
 run_cmd automake --add-missing --copy
 run_cmd autoconf

--- a/PyIlmBase/configure.ac
+++ b/PyIlmBase/configure.ac
@@ -33,6 +33,46 @@ fi
 
 export PKG_CONFIG_PATH
 
+dnl Enable and choose c++ standard
+AC_ARG_ENABLE(cxxstd,
+              AC_HELP_STRING([--enable-cxxstd=14],
+                             [enable ISO c++ standard 11/14 [[default=auto]]]),
+              [cxxstd="${enableval}"], [cxxstd=14])
+
+if test "${cxxstd}" == 17 ; then
+    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+	CXXFLAGS="$CXXFLAGS -std=c++17"
+else
+  if test "${cxxstd}" == 14 ; then
+      AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
+  	CXXFLAGS="$CXXFLAGS -std=c++14"
+  else
+    if test "${cxxstd}" == 11 ; then
+      AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+      CXXFLAGS="$CXXFLAGS -std=c++11"
+    else
+      if test "${cxxstd}" == 03 ; then
+        AC_DEFINE(ILMBASE_FORCE_CXX03)
+        CXXFLAGS="$CXXFLAGS -std=c++03"
+      else
+        dnl automatically determine...
+        AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
+        AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
+        if test "$HAVE_CXX14" == 1 ; then
+  	      CXXFLAGS="$CXXFLAGS -std=c++14"
+          cxxstd = 14
+        else
+          if test "$HAVE_CXX11" == 1 ; then
+  	        CXXFLAGS="$CXXFLAGS -std=c++11"
+            cxxstd = 11
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
 dnl
 dnl get ccflags and libs from openexr packages, then check 
 dnl whether test programs compile
@@ -69,14 +109,20 @@ LDFLAGS="$LDFLAGS $ILMBASE_LDFLAGS"
 
 dnl Checks for python and boost python
 AM_PATH_PYTHON
-PYTHON_INC_DIR=`$PYTHON -c 'from distutils.sysconfig import *; print get_python_inc()'`
-PYTHON_LIB_DIR=`$PYTHON -c 'from distutils.sysconfig import *; print get_config_var("LIBDIR")'`
-LIBS="$LIBS -lpython$PYTHON_VERSION"
+PYTHON_INC_DIR=`$PYTHON -c 'from distutils.sysconfig import *; print (get_python_inc())'`
+PYTHON_LIB_DIR=`$PYTHON -c 'from distutils.sysconfig import *; print (get_config_var("LIBDIR"))'`
+PYTHON_VER_MAJ=`echo $PYTHON_VERSION|cut -d. -f1`
+PKG_CHECK_MODULES(PYTHON, [python${PYTHON_VER_MAJ}])
+LIBS="$LIBS $PYTHON_LIBS"
 
 BOOST_PYTHON_CXXFLAGS="" 
 BOOST_PYTHON_LDFLAGS="" 
-BOOST_PYTHON_LIBS="" 
-BOOST_PYTHON_LIBNAME="boost_python"
+BOOST_PYTHON_LIBS=""
+if test "${PYTHON_VER_MAJ}" == 3 ; then
+  BOOST_PYTHON_LIBNAME="boost_python3"
+else
+  BOOST_PYTHON_LIBNAME="boost_python"
+fi
 
 AC_ARG_WITH(
    [boost-include-dir],
@@ -139,7 +185,7 @@ case "$host" in
   ;;
 esac
 
-NUMPY_CXXFLAGS=`$PYTHON -c 'from numpy.distutils.misc_util import *; import string; print string.join(@<:@"-I"+x for x in get_numpy_include_dirs()@:>@," ")'`
+NUMPY_CXXFLAGS=`$PYTHON -c 'from numpy.distutils.misc_util import *; import string; print (" ".join(@<:@"-I"+x for x in get_numpy_include_dirs()@:>@))'`
 
 AC_ARG_WITH([numpy],
   [AS_HELP_STRING([--without-numpy],


### PR DESCRIPTION
This propagates the same changes to configure.ac and cmakelists.txt to
enable compiling with c++11/14.

Additionally, adds some minor changes to configure to enable python 3 to
be configured (source code changes tbd)