### PR TITLE
Visual Studio and Windows fixes

### DIFF
--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -139,7 +139,7 @@ ENDIF ()
 
 IF (FORCE_CXX03)
   FILE ( APPEND  ${CMAKE_CURRENT_BINARY_DIR}/config/IlmBaseConfig.h "#define ILMBASE_FORCE_CXX03 1\n" )
-ELIF (NOT WIN32)
+ELSEIF (NOT WIN32)
   # really only care about c++11 right now for the threading bits, but this can be changed to 14
   # when needed...
   # Note that the __cplusplus check is not valid under MSVC

--- a/PyIlmBase/PyImath/CMakeLists.txt
+++ b/PyIlmBase/PyImath/CMakeLists.txt
@@ -52,6 +52,11 @@ INSTALL ( TARGETS PyImath
 	lib
 )
 
+INSTALL (DIRECTORY ./
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
+)
+
 ADD_LIBRARY ( imathmodule ${LIB_TYPE}
     imathmodule.cpp
     PyImathFun.cpp

--- a/PyIlmBase/PyImathNumpy/CMakeLists.txt
+++ b/PyIlmBase/PyImathNumpy/CMakeLists.txt
@@ -3,9 +3,18 @@ ADD_LIBRARY ( imathnumpymodule ${LIB_TYPE}
     imathnumpymodule.cpp
 )
 
-SET_TARGET_PROPERTIES ( imathnumpymodule
-	PROPERTIES PREFIX "" SUFFIX ".so" BUILD_WITH_INSTALL_RPATH ON
-)
+IF (WIN32)
+    SET_TARGET_PROPERTIES (imathnumpymodule
+        PROPERTIES
+            PREFIX ""
+            OUTPUT_NAME "imathnumpy"
+            SUFFIX ".pyd"
+    )
+ELSE ()
+    SET_TARGET_PROPERTIES (imathnumpymodule
+        PROPERTIES PREFIX "" SUFFIX ".so" BUILD_WITH_INSTALL_RPATH ON
+    )
+ENDIF ()
 
 INCLUDE_DIRECTORIES (
 	${NUMPY_INCLUDE_DIRS}


### PR DESCRIPTION
IlmBase: Fix IF/ELSEIF clause (WIN32 only)
PyImath: Install *.h in 'include' dir
PyImathNumpy: Change python library filename to 'imathnumpy.pyd' (WIN32 only)