### PR TITLE
Fix shebang line to bash

### DIFF
--- a/IlmBase/bootstrap
+++ b/IlmBase/bootstrap
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/OpenEXR/bootstrap
+++ b/OpenEXR/bootstrap
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/OpenEXR_Viewers/bootstrap
+++ b/OpenEXR_Viewers/bootstrap
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/PyIlmBase/bootstrap
+++ b/PyIlmBase/bootstrap
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then


### PR DESCRIPTION
Depending on the distro running the script the following error
might appear:

    ./bootstrap: 4: [: Linux: unexpected operator

This is because #!/bin/sh is not the same on every distro and this
script is actually expecting bash. So update the shebang line to
be bash.

Signed-off-by: Thanh Ha <thanh.ha@linuxfoundation.org>