### PR TITLE
Note that numpy is required to build PyIlmBase

### DIFF
--- a/PyIlmBase/README
+++ b/PyIlmBase/README
@@ -18,6 +18,13 @@ named COPYING (included in this distribution) for details.
 BUILDING ILMBASE
 ----------------
 
+PyIlmBase requires numpy to be available to the builder. Install with
+your favorite package manager or use a Python virtualenv:
+
+virtualenv numpy
+soure numpy/bin/activate
+pip install numpy
+
 To build IlmBase on GNU/Linux or other UNIX-like systems, do this:
 
 ./configure


### PR DESCRIPTION
Numpy needs to be available in order to successfully build PyIlmBase. Provide a note about that and virtualenv instructions for folks who cannot install it via their favorite package manager.