### PR TITLE
make code more amenable to compiling with mingw for cross-compiling

### DIFF
--- a/OpenEXR/IlmImf/ImfOptimizedPixelReading.h
+++ b/OpenEXR/IlmImf/ImfOptimizedPixelReading.h
@@ -70,7 +70,7 @@ EXR_FORCEINLINE
 bool
 isPointerSSEAligned (const void* EXR_RESTRICT pPointer)
 {
-    unsigned long trailingBits = ((unsigned long)pPointer) & 15;
+    uintptr_t trailingBits = ((uintptr_t)pPointer) & 15;
     return trailingBits == 0;
 }
 

--- a/OpenEXR/IlmImf/ImfSystemSpecific.h
+++ b/OpenEXR/IlmImf/ImfSystemSpecific.h
@@ -54,7 +54,7 @@ static bool GLOBAL_SYSTEM_LITTLE_ENDIAN =
 
 #ifdef IMF_HAVE_SSE2
 
-#ifdef __GNUC__
+#if defined(__GNUC__)
 // Causes issues on certain gcc versions
 //#define EXR_FORCEINLINE inline __attribute__((always_inline))
 #define EXR_FORCEINLINE inline
@@ -62,15 +62,24 @@ static bool GLOBAL_SYSTEM_LITTLE_ENDIAN =
 
 static void* EXRAllocAligned(size_t size, size_t alignment)
 {
+    // GNUC is used for things like mingw to (cross-)compile for windows
+#ifdef _WIN32
+    return _aligned_malloc(size, alignment);
+#else
     void* ptr = 0;
     posix_memalign(&ptr, alignment, size);
     return ptr;
+#endif
 }
 
 
 static void EXRFreeAligned(void* ptr)
 {
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
     free(ptr);
+#endif
 }
 
 #elif defined _MSC_VER


### PR DESCRIPTION
This adds a couple of ifdefs and a pointer type change to be more correct when cross compiling windows under linux using mingw (gcc).

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>