### PR TITLE
renames name to message and removes implicit cast

### DIFF
--- a/IlmBase/Iex/IexBaseExc.cpp
+++ b/IlmBase/Iex/IexBaseExc.cpp
@@ -138,7 +138,7 @@ BaseExc::append (std::stringstream &s)
 //-----------------
 
 const std::string &
-BaseExc::name() const
+BaseExc::message() const
 {
 	return _what;
 }

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -92,7 +92,7 @@ class BaseExc: public std::exception
     //--------------------------------------------
 
     IEX_EXPORT virtual const char * what () const throw ();
-    IEX_EXPORT const std::string &  name() const;
+    IEX_EXPORT const std::string &  message() const;
 
 
     //--------------------------------------------------
@@ -126,12 +126,6 @@ class BaseExc: public std::exception
     //--------------------------------------------------
 
     IEX_EXPORT const std::string &  stackTrace () const;
-
-
-    //--------------------------------------------------
-    // Conversion operators.
-    //--------------------------------------------------
-    IEX_EXPORT operator		const char *() const { return what(); }
 
 
   private:

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -980,7 +980,7 @@ DeepScanLineInputFile::DeepScanLineInputFile
         if (_data)       delete _data;
 
         REPLACE_EXC (e, "Cannot read image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1366,7 +1366,7 @@ DeepScanLineInputFile::readPixels (int scanLine1, int scanLine2)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading pixel data from image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1994,7 +1994,7 @@ DeepScanLineInputFile::readPixelSampleCounts (int scanline1, int scanline2)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading sample count data from image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
 
         _data->_streamData->is->seekg(savedFilePos);
 

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -841,7 +841,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile
         delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -885,7 +885,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile
         delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << os.fileName() << "\". " << e);
+                     "\"" << os.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -917,7 +917,7 @@ DeepScanLineOutputFile::DeepScanLineOutputFile(const OutputPartData* part)
         delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
-                        "\"" << part->partNumber << "\". " << e);
+                     "\"" << part->partNumber << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1388,7 +1388,7 @@ DeepScanLineOutputFile::writePixels (int numScanLines)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Failed to write pixel data to image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1545,7 +1545,7 @@ DeepScanLineOutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Cannot update preview image pixels for "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -829,7 +829,7 @@ DeepTiledInputFile::DeepTiledInputFile (const char fileName[], int numThreads):
         if (_data)       delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -883,7 +883,7 @@ DeepTiledInputFile::DeepTiledInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream 
         if (_data)       delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << is.fileName() << "\". " << e);
+                     "\"" << is.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1363,7 +1363,7 @@ DeepTiledInputFile::readTiles (int dx1, int dx2, int dy1, int dy2, int lx, int l
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading pixel data from image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1588,7 +1588,7 @@ DeepTiledInputFile::levelWidth (int lx) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling levelWidth() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1605,7 +1605,7 @@ DeepTiledInputFile::levelHeight (int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling levelHeight() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1661,7 +1661,7 @@ DeepTiledInputFile::dataWindowForLevel (int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling dataWindowForLevel() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1691,7 +1691,7 @@ DeepTiledInputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling dataWindowForTile() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1900,7 +1900,7 @@ DeepTiledInputFile::readPixelSampleCounts (int dx1, int dx2,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading sample count data from image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
 
          _data->_streamData->is->seekg(savedFilePos);
 

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -1079,7 +1079,7 @@ DeepTiledOutputFile::DeepTiledOutputFile
         if (_data)           delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1122,7 +1122,7 @@ DeepTiledOutputFile::DeepTiledOutputFile
         if (_data)       delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << os.fileName() << "\". " << e);
+                     "\"" << os.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1157,7 +1157,7 @@ DeepTiledOutputFile::DeepTiledOutputFile(const OutputPartData* part)
         if (_data) delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
-                        "\"" << part->partNumber << "\". " << e);
+                     "\"" << part->partNumber << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1625,7 +1625,7 @@ DeepTiledOutputFile::writeTiles (int dx1, int dx2, int dy1, int dy2,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Failed to write pixel data to image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1864,7 +1864,7 @@ DeepTiledOutputFile::levelWidth (int lx) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling levelWidth() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1881,7 +1881,7 @@ DeepTiledOutputFile::levelHeight (int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling levelHeight() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1932,7 +1932,7 @@ DeepTiledOutputFile::dataWindowForLevel (int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling dataWindowForLevel() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1963,7 +1963,7 @@ DeepTiledOutputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error calling dataWindowForTile() on image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -2020,7 +2020,7 @@ DeepTiledOutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Cannot update preview image pixels for "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -396,7 +396,7 @@ InputFile::InputFile (const char fileName[], int numThreads):
         _data=NULL;
 
         REPLACE_EXC (e, "Cannot read image file "
-			"\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -457,7 +457,7 @@ InputFile::InputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int numThread
         _data=NULL; 
 
         REPLACE_EXC (e, "Cannot read image file "
-			"\"" << is.fileName() << "\". " << e);
+                     "\"" << is.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -848,7 +848,7 @@ InputFile::rawPixelData (int firstScanLine,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error reading pixel data from image "
-		        "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -880,7 +880,7 @@ InputFile::rawPixelDataToBuffer (int scanLine,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading pixel data from image "
-                     "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -906,7 +906,7 @@ InputFile::rawTileData (int &dx, int &dy,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error reading tile data from image "
-		        "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -141,7 +141,7 @@ MultiPartInputFile::MultiPartInputFile(const char fileName[],
         delete _data;
 
         REPLACE_EXC (e, "Cannot read image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -167,7 +167,7 @@ MultiPartInputFile::MultiPartInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream&
         delete _data;
 
         REPLACE_EXC (e, "Cannot read image file "
-                        "\"" << is.fileName() << "\". " << e);
+                     "\"" << is.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
@@ -230,7 +230,7 @@ MultiPartOutputFile::MultiPartOutputFile (const char fileName[],
         delete _data;
 
         REPLACE_EXC (e, "Cannot open image file "
-                        "\"" << fileName << "\". " << e);
+                     "\"" << fileName << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -277,7 +277,7 @@ MultiPartOutputFile::MultiPartOutputFile(OStream& os,
         delete _data;
         
         REPLACE_EXC (e, "Cannot open image stream "
-        "\"" << os.fileName() << "\". " << e);
+                     "\"" << os.fileName() << "\". " << e.what());
         throw;
     }
     catch (...)

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -683,7 +683,7 @@ OutputFile::OutputFile
         delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << fileName << "\". " << e);
+                 "\"" << fileName << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -728,7 +728,7 @@ OutputFile::OutputFile
 	if (_data)       delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << os.fileName() << "\". " << e);
+                 "\"" << os.fileName() << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -762,7 +762,7 @@ OutputFile::OutputFile(const OutputPartData* part) : _data(NULL)
         if (_data) delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
-                        "\"" << part->partNumber << "\". " << e);
+                     "\"" << part->partNumber << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1205,7 +1205,7 @@ OutputFile::writePixels (int numScanLines)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Failed to write pixel data to image "
-		        "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1350,7 +1350,7 @@ OutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Cannot update preview image pixels for "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1657,7 +1657,7 @@ ScanLineInputFile::readPixels (int scanLine1, int scanLine2)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error reading pixel data from image "
-		        "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1696,7 +1696,7 @@ ScanLineInputFile::rawPixelData (int firstScanLine,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error reading pixel data from image "
-		        "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1729,7 +1729,7 @@ void ScanLineInputFile::rawPixelDataToBuffer(int scanLine,
   catch (IEX_NAMESPACE::BaseExc &e) 
   {
     REPLACE_EXC (e, "Error reading pixel data from image "
-                   "file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
     throw;
   }
 }

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -740,7 +740,7 @@ TiledInputFile::TiledInputFile (const char fileName[], int numThreads):
             delete is;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << fileName << "\". " << e);
+                 "\"" << fileName << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -803,7 +803,7 @@ TiledInputFile::TiledInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int
 	delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << is.fileName() << "\". " << e);
+                 "\"" << is.fileName() << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -1248,7 +1248,7 @@ TiledInputFile::readTiles (int dx1, int dx2, int dy1, int dy2, int lx, int ly)
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading pixel data from image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1318,7 +1318,7 @@ TiledInputFile::rawTileData (int &dx, int &dy,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Error reading pixel data from image "
-			"file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1406,7 +1406,7 @@ TiledInputFile::levelWidth (int lx) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling levelWidth() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1423,7 +1423,7 @@ TiledInputFile::levelHeight (int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling levelHeight() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1479,7 +1479,7 @@ TiledInputFile::dataWindowForLevel (int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling dataWindowForLevel() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1509,7 +1509,7 @@ TiledInputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling dataWindowForTile() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -881,7 +881,7 @@ TiledOutputFile::TiledOutputFile
 	delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << fileName << "\". " << e);
+                 "\"" << fileName << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -923,7 +923,7 @@ TiledOutputFile::TiledOutputFile
 	delete _data;
 
 	REPLACE_EXC (e, "Cannot open image file "
-			"\"" << os.fileName() << "\". " << e);
+                 "\"" << os.fileName() << "\". " << e.what());
 	throw;
     }
     catch (...)
@@ -955,7 +955,7 @@ TiledOutputFile::TiledOutputFile(const OutputPartData* part) :
         delete _data;
 
         REPLACE_EXC (e, "Cannot initialize output part "
-                        "\"" << part->partNumber << "\". " << e);
+                     "\"" << part->partNumber << "\". " << e.what());
         throw;
     }
     catch (...)
@@ -1385,7 +1385,7 @@ TiledOutputFile::writeTiles (int dx1, int dx2, int dy1, int dy2,
     catch (IEX_NAMESPACE::BaseExc &e)
     {
         REPLACE_EXC (e, "Failed to write pixel data to image "
-                        "file \"" << fileName() << "\". " << e);
+                     "file \"" << fileName() << "\". " << e.what());
         throw;
     }
 }
@@ -1652,7 +1652,7 @@ TiledOutputFile::levelWidth (int lx) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling levelWidth() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1669,7 +1669,7 @@ TiledOutputFile::levelHeight (int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling levelHeight() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1720,7 +1720,7 @@ TiledOutputFile::dataWindowForLevel (int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling dataWindowForLevel() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1751,7 +1751,7 @@ TiledOutputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Error calling dataWindowForTile() on image "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }
@@ -1808,7 +1808,7 @@ TiledOutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     catch (IEX_NAMESPACE::BaseExc &e)
     {
 	REPLACE_EXC (e, "Cannot update preview image pixels for "
-			"file \"" << fileName() << "\". " << e);
+                 "file \"" << fileName() << "\". " << e.what());
 	throw;
     }
 }


### PR DESCRIPTION
This removes the implicit cast, which is arguably more "standard", and
also less surprising. Further, renames the name function to message to
match internal ILM changes, and message makes more sense as a function
name than ... name.