### PR TITLE
restore prefix, update to use PKG_CHECK_MODULES

### DIFF
--- a/OpenEXR/IlmImf/Makefile.am
+++ b/OpenEXR/IlmImf/Makefile.am
@@ -93,7 +93,7 @@ libIlmImf_la_SOURCES = ImfForward.h ImfAttribute.cpp ImfBoxAttribute.cpp ImfCRgb
 	               ImfSystemSpecific.cpp ImfZip.h ImfZip.cpp
 
 
-libIlmImf_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ \
+libIlmImf_la_LDFLAGS = @ILMBASE_LDFLAGS@ -version-info @LIBTOOL_VERSION@ \
 			-no-undefined 
 
 
@@ -189,7 +189,7 @@ noinst_HEADERS = ImfCompressor.h    \
 EXTRA_DIST = $(noinst_HEADERS) b44ExpLogTable.cpp b44ExpLogTable.h dwaLookups.cpp dwaLookups.h CMakeLists.txt
 
 
-INCLUDES = \
+INCLUDES = @ILMBASE_CXXFLAGS@ \
 	   -I$(top_builddir) \
 	   -I$(top_srcdir)/config \
 	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
@@ -197,13 +197,13 @@ INCLUDES = \
 CLEANFILES = b44ExpLogTable b44ExpLogTable.h dwaLookups dwaLookups.h
 
 b44ExpLogTable_SOURCES = b44ExpLogTable.cpp
-b44ExpLogTable_LDADD = $(ILMBASE_LIBS)
+b44ExpLogTable_LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS)
 
 b44ExpLogTable.h: b44ExpLogTable
 	./b44ExpLogTable > b44ExpLogTable.h
 
 dwaLookups_SOURCES = dwaLookups.cpp
-dwaLookups_LDADD = $(ILMBASE_LIBS)
+dwaLookups_LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS)
 
 dwaLookups.h: dwaLookups
 	./dwaLookups > dwaLookups.h

--- a/OpenEXR/IlmImfExamples/Makefile.am
+++ b/OpenEXR/IlmImfExamples/Makefile.am
@@ -6,10 +6,10 @@ endif
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	$(ILMBASE_LIBS) \
+	@ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	-lIlmImf $(ZLIB_CFLAGS)
 
 imfexamples_SOURCES = main.cpp drawImage.cpp rgbaInterfaceExamples.cpp \

--- a/OpenEXR/IlmImfFuzzTest/Makefile.am
+++ b/OpenEXR/IlmImfFuzzTest/Makefile.am
@@ -14,10 +14,10 @@ IlmImfFuzzTest_SOURCES = fuzzFile.cpp fuzzFile.h main.cpp tmpDir.h \
 INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/config \
-	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+	   @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	$(ILMBASE_LIBS) \
+	@ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	-lIlmImf $(ZLIB_LIBS)
 
 if BUILD_IMFFUZZTEST

--- a/OpenEXR/IlmImfTest/Makefile.am
+++ b/OpenEXR/IlmImfTest/Makefile.am
@@ -64,10 +64,10 @@ endif
 INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/config \
-	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+	   @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
-	$(ILMBASE_LIBS) \
+	@ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	-lIlmImf $(ZLIB_LIBS)
 
 TESTS = IlmImfTest

--- a/OpenEXR/IlmImfUtil/Makefile.am
+++ b/OpenEXR/IlmImfUtil/Makefile.am
@@ -18,7 +18,6 @@ libIlmImfUtil_la_SOURCES = \
 	ImfDeepImageIO.h ImfDeepImageIO.cpp \
 	ImfImageDataWindow.h ImfImageDataWindow.cpp \
 	ImfImageChannelRenaming.h
-	
 
 libIlmImfUtil_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ \
 			-no-undefined 
@@ -39,5 +38,5 @@ INCLUDES = \
 	   -I$(top_builddir) \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/config \
-	   $(ILMBASE_CFLAGS)
+	   @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS)
 

--- a/OpenEXR/IlmImfUtilTest/Makefile.am
+++ b/OpenEXR/IlmImfUtilTest/Makefile.am
@@ -11,11 +11,11 @@ INCLUDES = -I$(top_builddir)  \
 	   -I$(top_srcdir)/IlmImf \
 	   -I$(top_srcdir)/IlmImfUtil \
 	   -I$(top_srcdir)/config \
-	   $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+	   @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
 LDADD = -L$(top_builddir)/IlmImf \
 	-L$(top_builddir)/IlmImfUtil \
-	$(ILMBASE_LIBS) \
+	@ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	-lIlmImfUtil -lIlmImf $(ZLIB_LIBS)
 
 TESTS = IlmImfUtilTest

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -34,8 +34,19 @@ AC_PROG_MAKE_SET
 dnl
 dnl PKGCONFIG preparations
 dnl
-PKG_CHECK_MODULES([ILMBASE], [IlmBase])
+AM_PATH_PKGCONFIG(
+    [ILMBASE_CXXFLAGS],
+    [ILMBASE_LDFLAGS],
+    [ILMBASE_LIBS],
+    [IlmBase],
+    [OpenEXR],
+    [],
+    [-lImath -lHalf -lIlmThread -lIex -lpthread],
+    [ilmbase-prefix],
+    [ILMBASE])
 
+dnl Checks for zlib
+PKG_CHECK_MODULES([ZLIB], [zlib])
 
 dnl Define the version string
 AC_DEFINE_UNQUOTED([OPENEXR_VERSION_STRING], "${VERSION}", [OpenEXR version string])
@@ -151,13 +162,29 @@ AC_C_CONST
 AC_C_INLINE
 AC_TYPE_SIZE_T
 
-dnl Checks for zlib
-PKG_CHECK_MODULES([ZLIB], [zlib])
-
-
-dnl We use a modern toolchain, don't care
-dnl about ancient broken stuff
+dnl don't need this check anymore..
+dnl dnl Checks for std::right etc. in iomanip
+dnl AC_MSG_CHECKING(for complete iomanip support in C++ standard library)
+dnl complete_iomanip="no"
+dnl AC_LANG_SAVE
+dnl AC_LANG_CPLUSPLUS
+dnl AC_TRY_COMPILE([#include <iomanip>],[
+dnl  	std::right;
+dnl ],
+dnl AC_DEFINE(OPENEXR_IMF_HAVE_COMPLETE_IOMANIP) complete_iomanip=yes)
+dnl
+dnl AC_MSG_RESULT($complete_iomanip)
+dnl AC_LANG_RESTORE
 AC_DEFINE([OPENEXR_IMF_HAVE_COMPLETE_IOMANIP], [1], [Define when std::right is available])
+
+AC_MSG_CHECKING(for gcc optimization flags)
+old_cflags=$CFLAGS
+CFLAGS="$CFLAGS -pipe"
+AC_TRY_COMPILE([#include <stdio.h>],
+[ printf ("hello, world"); ],
+[ EXTRA_OPT_CFLAGS="-pipe"],[ EXTRA_OPT_CFLAGS=""])
+CFLAGS=$old_cflags
+AC_MSG_RESULT([$EXTRA_OPT_CFLAGS])
 
 
 dnl Check to see if the toolset supports AVX instructions in inline asm
@@ -173,6 +200,10 @@ AS_IF([test "x$enable_avx" = "xyes"], [
 	gcc_inline_asm_avx="no"
 ])
 
+AM_CFLAGS="$EXTRA_OPT_CFLAGS"
+AM_CXXFLAGS="$EXTRA_OPT_CFLAGS"
+AC_SUBST(AM_CFLAGS)
+AC_SUBST(AM_CXXFLAGS)
 
 dnl Check if sysconf(_SC_NPROCESSORS_ONLN) can be used for CPU count
 AC_MSG_CHECKING([for sysconf(_SC_NPROCESSORS_ONLN)])
@@ -219,6 +250,7 @@ Please re-run configure with these options:
 
   ;;
 esac
+
 
 dnl build imfexamples example program?
 build_imfexamples="no"

--- a/OpenEXR/exrenvmap/Makefile.am
+++ b/OpenEXR/exrenvmap/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrenvmap
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrheader/Makefile.am
+++ b/OpenEXR/exrheader/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrheader
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrmakepreview/Makefile.am
+++ b/OpenEXR/exrmakepreview/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrmakepreview
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrmaketiled/Makefile.am
+++ b/OpenEXR/exrmaketiled/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrmaketiled
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrmultipart/Makefile.am
+++ b/OpenEXR/exrmultipart/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrmultipart
 
 INCLUDES = -I$(top_builddir) \
 -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-$(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+@ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrmultiview/Makefile.am
+++ b/OpenEXR/exrmultiview/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrmultiview
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/exrstdattr/Makefile.am
+++ b/OpenEXR/exrstdattr/Makefile.am
@@ -4,9 +4,9 @@ bin_PROGRAMS = exrstdattr
 
 INCLUDES = -I$(top_builddir) \
            -I$(top_srcdir)/IlmImf -I$(top_srcdir)/config \
-           $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
+           @ILMBASE_CXXFLAGS@ $(ILMBASE_CFLAGS) $(ZLIB_CFLAGS)
 
-LDADD = $(ILMBASE_LIBS) \
+LDADD = @ILMBASE_LDFLAGS@ $(ILMBASE_LIBS) \
 	$(top_builddir)/IlmImf/libIlmImf.la \
 	$(ZLIB_LIBS)
 

--- a/OpenEXR/m4/path.pkgconfig.m4
+++ b/OpenEXR/m4/path.pkgconfig.m4
@@ -42,6 +42,7 @@ define([arg_include_subdir],$5)
 define([arg_default_ldflags],$6)
 define([arg_default_libs],$7)
 define([arg_test_prefix],$8)
+define([arg_pkg_prefix],$9)
 
 TEST_CXXFLAGS=""
 TEST_LDFLAGS=""
@@ -72,40 +73,28 @@ else
    dnl the -L flags will appear twice on the command line, but we can not
    dnl limit it to --libs-only-l because it may include the "-pthread" flag.
    dnl 
-   if test x$PKG_CONFIG != xno ; then
-      echo "using pkg-config to set arg_cxxflags and arg_ldflags:"
-      TEST_CXXFLAGS="`$PKG_CONFIG --cflags arg_pkg_name`"
-      TEST_LDFLAGS="`$PKG_CONFIG --libs-only-L arg_pkg_name`"
-      TEST_LIBS="`$PKG_CONFIG --libs arg_pkg_name`"
-   else
-      echo "Not using pkg-config."
-      TEST_CXXFLAGS=""
-      TEST_LDFLAGS=""
-      TEST_LIBS=""
-   fi
-
-   dnl
-   dnl if the flags are still not set, try a prefix and finally a default
-   dnl
-   if test -z "${TEST_CXXFLAGS}"; then
-      TEST_CXXFLAGS=""
-      if test "x$prefix" != "xNONE"; then
-         echo "using prefix to set arg_cxxflags and arg_ldflags:"
-         for inc_dir in arg_include_subdir
-         do
-            TEST_CXXFLAGS="$TEST_CXXFLAGS -I$prefix/include/$inc_dir"
-         done
-         TEST_LDFLAGS="-L$prefix/lib"
-      else
-         echo "using default as guess for arg_cxxflags and arg_ldflags:"
-         for inc_dir in arg_include_subdir
-         do
-             TEST_CXXFLAGS="$TEST_CXXFLAGS -I/usr/local/include/$inc_dir"
-         done
-         TEST_LDFLAGS="arg_default_ldflags"
+   PKG_CHECK_MODULES([arg_pkg_prefix], [arg_pkg_name], [],
+      [
+      if test -z "${TEST_CXXFLAGS}"; then
+         TEST_CXXFLAGS=""
+         if test "x$prefix" != "xNONE"; then
+            echo "using prefix to set arg_cxxflags and arg_ldflags:"
+            for inc_dir in arg_include_subdir
+            do
+               TEST_CXXFLAGS="$TEST_CXXFLAGS -I$prefix/include/$inc_dir"
+            done
+            TEST_LDFLAGS="-L$prefix/lib"
+         else
+            echo "using default as guess for arg_cxxflags and arg_ldflags:"
+            for inc_dir in arg_include_subdir
+            do
+               TEST_CXXFLAGS="$TEST_CXXFLAGS -I/usr/local/include/$inc_dir"
+            done
+            TEST_LDFLAGS="arg_default_ldflags"
+         fi
+         TEST_LIBS="arg_default_libs"
       fi
-      TEST_LIBS="arg_default_libs"
-   fi
+      ])
 fi
 
 echo "    arg_cxxflags = $TEST_CXXFLAGS"


### PR DESCRIPTION
previous commit from dracwyrm had made it such that pkg-config must be
used and ilmbase must be installed in the default pkg-config path by
default. restore the original behaviour by which a prefix could be
provided, yet still retain use of PKG_CHECK_MODULES to find IlmBase if
the prefix is not specified, and continue to use pkg-config to find zlib
instead of assuming -lz

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>