### PR TITLE
Fallback default system provided Boost Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,8 +122,13 @@ if (OPENEXR_BUILD_PYTHON_LIBS)
 
   find_package(Boost COMPONENTS python${OPENEXR_PYTHON_MAJOR}${OPENEXR_PYTHON_MINOR})
   if(NOT Boost_PYTHON${OPENEXR_PYTHON_MAJOR}${OPENEXR_PYTHON_MINOR}_FOUND)
-    message(WARNING "Make boost Python${OPENEXR_PYTHON_MAJOR}${OPENEXR_PYTHON_MINOR} available to CMake's search path, and re-run configuration")
-    message(FATAL_ERROR "boost Python is a required dependency when OPENEXR_BUILD_PYTHON_LIBS is set")
+    message(WARNING "user provided Boost Python${OPENEXR_PYTHON_MAJOR}${OPENEXR_PYTHON_MINOR} was not found. Trying default path...")
+
+    find_package(Boost COMPONENTS python)
+    if(NOT Boost_PYTHON_FOUND)
+      message(WARNING "Make boost Python available to CMake's search path, and re-run configuration")
+      message(FATAL_ERROR "boost Python is a required dependency when OPENEXR_BUILD_PYTHON_LIBS is set")
+    endif()
   endif()
 
   find_package(NumPy)


### PR DESCRIPTION
User provided Python version via OPENEXR_PYTHON_MAJOR and
OPENEXR_PYTHON_MINOR parameters, failing that fallback onto
the system's default "python" whichever that may be.

Signed-off-by: Thanh Ha <thanh.ha@linuxfoundation.org>